### PR TITLE
Warning fixes

### DIFF
--- a/libpng/png.c
+++ b/libpng/png.c
@@ -107,7 +107,7 @@ png_zfree(voidpf png_ptr, voidpf ptr)
 void /* PRIVATE */
 png_reset_crc(png_structp png_ptr)
 {
-   png_ptr->crc = crc32(0, Z_NULL, 0);
+   png_ptr->crc = (png_uint_32)crc32(0, Z_NULL, 0);
 }
 
 /* Calculate the CRC over a section of data.  We can only pass as
@@ -134,7 +134,7 @@ png_calculate_crc(png_structp png_ptr, png_const_bytep ptr, png_size_t length)
    }
 
    if (need_crc)
-      png_ptr->crc = crc32(png_ptr->crc, ptr, (uInt)length);
+      png_ptr->crc = (png_uint_32)crc32(png_ptr->crc, ptr, (uInt)length);
 }
 
 /* Check a user supplied version number, called from both read and write

--- a/libpng/pngset.c
+++ b/libpng/pngset.c
@@ -577,7 +577,7 @@ png_set_iCCP(png_structp png_ptr, png_infop info_ptr,
    if (png_ptr == NULL || info_ptr == NULL || name == NULL || profile == NULL)
       return;
 
-   length = png_strlen(name)+1;
+   length = (png_uint_32)(png_strlen(name)+1);
    new_iccp_name = (png_charp)png_malloc_warn(png_ptr, length);
 
    if (new_iccp_name == NULL)
@@ -918,7 +918,7 @@ png_set_sPLT(png_structp png_ptr,
       png_const_sPLT_tp from = entries + i;
       png_uint_32 length;
 
-      length = png_strlen(from->name) + 1;
+      length = (png_uint_32)(png_strlen(from->name) + 1);
       to->name = (png_charp)png_malloc_warn(png_ptr, (png_size_t)length);
 
       if (to->name == NULL)

--- a/libpng/pngwutil.c
+++ b/libpng/pngwutil.c
@@ -1884,7 +1884,7 @@ png_write_pCAL(png_structp png_ptr, png_charp purpose, png_int_32 X0,
     */
    for (i = 0; i < nparams; i++)
    {
-      params_len[i] = png_strlen(params[i]) + (i == nparams - 1 ? 0 : 1);
+      params_len[i] = (png_uint_32)(png_strlen(params[i]) + (i == nparams - 1 ? 0 : 1));
       png_debug2(3, "pCAL parameter %d length = %lu", i,
           (unsigned long)params_len[i]);
       total_len += (png_size_t)params_len[i];

--- a/snes_spc/SNES_SPC_misc.cpp
+++ b/snes_spc/SNES_SPC_misc.cpp
@@ -309,7 +309,7 @@ void SNES_SPC::set_output( sample_t* out, int size )
 			assert( out <= out_end );
 		}
 		
-		dsp.set_output( out, out_end - out );
+		dsp.set_output( out, static_cast<int>(out_end - out) );
 	}
 	else
 	{

--- a/snes_spc/SPC_CPU.h
+++ b/snes_spc/SPC_CPU.h
@@ -93,7 +93,7 @@
 #else
 #define PUSH16( data )\
 {\
-	int addr = (sp -= 2) - ram;\
+	int addr = static_cast<int>((sp -= 2) - ram);\
 	if ( addr > 0x100 )\
 	{\
 		SET_LE16( sp, data );\
@@ -248,7 +248,7 @@ loop:
 		BRANCH( (uint8_t) nz )
 	
 	case 0x3F:{// CALL
-		int old_addr = GET_PC() + 2;
+		int old_addr = static_cast<int>(GET_PC() + 2);
 		SET_PC( READ_PC16( pc ) );
 		PUSH16( old_addr );
 		goto loop;
@@ -262,7 +262,7 @@ loop:
 		}
 		#else
 		{
-			int addr = sp - ram;
+			int addr = static_cast<int>(sp - ram);
 			SET_PC( GET_LE16( sp ) );
 			sp += 2;
 			if ( addr < 0x1FF )
@@ -480,7 +480,7 @@ loop:
 		goto loop;
 	
 	case 0x9D: // MOV X,SP
-		x = nz = GET_SP();
+		x = nz = static_cast<int>(GET_SP());
 		goto loop;
 	
 	case 0xBD: // MOV SP,X
@@ -964,7 +964,7 @@ loop:
 	
 	case 0x0F:{// BRK
 		int temp;
-		int ret_addr = GET_PC();
+		int ret_addr = static_cast<int>(GET_PC());
 		SUSPICIOUS_OPCODE( "BRK" );
 		SET_PC( READ_PROG16( 0xFFDE ) ); // vector address verified
 		PUSH16( ret_addr );
@@ -975,7 +975,7 @@ loop:
 	}
 	
 	case 0x4F:{// PCALL offset
-		int ret_addr = GET_PC() + 1;
+		int ret_addr = static_cast<int>(GET_PC() + 1);
 		SET_PC( 0xFF00 | data );
 		PUSH16( ret_addr );
 		goto loop;
@@ -997,7 +997,7 @@ loop:
 	case 0xD1:
 	case 0xE1:
 	case 0xF1: {
-		int ret_addr = GET_PC();
+		int ret_addr = static_cast<int>(GET_PC());
 		SET_PC( READ_PROG16( 0xFFDE - (opcode >> 3) ) );
 		PUSH16( ret_addr );
 		goto loop;
@@ -1185,7 +1185,7 @@ loop:
 	
 	case 0xFF:{// STOP
 		// handle PC wrap-around
-		unsigned addr = GET_PC() - 1;
+		unsigned addr = static_cast<unsigned>(GET_PC() - 1);
 		if ( addr >= 0x10000 )
 		{
 			addr &= 0xFFFF;

--- a/snes_spc/SPC_DSP.h
+++ b/snes_spc/SPC_DSP.h
@@ -154,7 +154,7 @@ private:
 
 #include <assert.h>
 
-inline int SPC_DSP::sample_count() const { return m.out - m.out_begin; }
+inline int SPC_DSP::sample_count() const { return static_cast<int>(m.out - m.out_begin); }
 
 inline int SPC_DSP::read( int addr ) const
 {

--- a/source/Confuse/confuse.cpp
+++ b/source/Confuse/confuse.cpp
@@ -536,7 +536,7 @@ cfg_value_t *cfg_setopt(cfg_t *cfg, cfg_opt_t *opt, const char *value)
       else 
       {
          // haleyjd 11/10/08: modified to print invalid values
-         val->number = strtol(value, &endptr, 0);
+         val->number = static_cast<int>(strtol(value, &endptr, 0));
          if(*endptr != '\0')
          {            
             cfg_error(cfg, "invalid integer value '%s' for option '%s'\n",

--- a/source/acs_acs0.cpp
+++ b/source/acs_acs0.cpp
@@ -696,7 +696,7 @@ static void ACS_translateScriptACS0(acs0_tracer_t *tracer, int32_t *codeIndexMap
       opdata = &ACS0opdata[op];
 
       // Record jump target.
-      codeIndexMap[index] = codePtr - tracer->vm->code;
+      codeIndexMap[index] = static_cast<int32_t>(codePtr - tracer->vm->code);
 
       // Calculate next index.
       index += ACS_countOpSizeACS0(tracer, index, opSize, opdata);
@@ -1250,7 +1250,7 @@ uint32_t ACS_LoadStringACS0(const byte *begin, const byte *end)
          buf += *itr++;
    }
 
-   return ACSVM::AddString(buf.constPtr(), buf.length());
+   return ACSVM::AddString(buf.constPtr(), static_cast<uint32_t>(buf.length()));
 }
 
 // EOF

--- a/source/acs_func.cpp
+++ b/source/acs_func.cpp
@@ -454,7 +454,7 @@ static void ACS_funcGetCVarString(ACS_FUNCARG)
    }
 
    const char *val = C_VariableValue(var);
-   *retn++ = ACSVM::AddString(val, strlen(val));
+   *retn++ = ACSVM::AddString(val, static_cast<uint32_t>(strlen(val)));
 }
 
 //
@@ -654,7 +654,7 @@ int32_t ACS_GetThingVar(Mobj *thing, uint32_t var)
    case ACS_THINGVAR_MomY:           return thing->momy;
    case ACS_THINGVAR_MomZ:           return thing->momz;
    case ACS_THINGVAR_Pitch:          return thing->player ? thing->player->pitch >> 16 : 0;
-   case ACS_THINGVAR_PlayerNumber:   return thing->player ? thing->player - players : -1;
+   case ACS_THINGVAR_PlayerNumber:   return static_cast<int32_t>(thing->player ? thing->player - players : -1);
    case ACS_THINGVAR_SigilPieces:    return 0;
    case ACS_THINGVAR_TID:            return thing->tid;
    case ACS_THINGVAR_Type:           return ACSVM::AddString(thing->info->name);

--- a/source/acs_intr.cpp
+++ b/source/acs_intr.cpp
@@ -165,7 +165,7 @@ ACSArray ACSglobalarrs[ACS_NUM_GLOBALARRS];
 //
 static void ACS_addVirtualMachine(ACSVM *vm)
 {
-   vm->id = acsVMs.getLength();
+   vm->id = static_cast<uint32_t>(acsVMs.getLength());
    acsVMs.add(vm);
 }
 
@@ -875,7 +875,7 @@ void ACSThinker::Think()
          }
 
          // Ensure there's enough stack space.
-         if(numStack - (stackPtr = stp - stack) < ACS_NUM_STACK)
+         if(numStack - (stackPtr = static_cast<uint32_t>(stp - stack)) < ACS_NUM_STACK)
          {
             numStack = stackPtr + ACS_NUM_STACK * 2;
             stack = (int32_t *)Z_Realloc(stack, numStack * sizeof(int32_t), PU_LEVEL, NULL);
@@ -937,7 +937,7 @@ void ACSThinker::Think()
          // Search for matching case using binary search.
          if(temp) for(;;)
          {
-            temp = caseEnd - caseBegin;
+            temp = static_cast<int32_t>(caseEnd - caseBegin);
             caseItr = caseBegin + (temp / 2);
 
             if((*caseItr)[0] == PEEK())
@@ -1087,7 +1087,7 @@ void ACSThinker::Think()
       popPrint();
       NEXTOP();
    OPCODE(ENDPRINTSTRING):
-      PUSH(ACSVM::AddString(printBuffer->constPtr(), printBuffer->length()));
+      PUSH(ACSVM::AddString(printBuffer->constPtr(), static_cast<uint32_t>(printBuffer->length())));
       popPrint();
       NEXTOP();
    OPCODE(PRINTMAPARRAY):
@@ -1250,7 +1250,7 @@ action_endscript:
 action_stop:
    // copy fields back into script
    this->ip  = ip;
-   this->stackPtr = stp - this->stack;
+   this->stackPtr = static_cast<uint32_t>(stp - this->stack);
    goto function_end;
 
 function_end:;
@@ -1278,7 +1278,7 @@ void ACSThinker::popPrint()
 //
 void ACSThinker::pushPrint()
 {
-   uint32_t printIndex = printPtr - printStack;
+   uint32_t printIndex = static_cast<uint32_t>(printPtr - printStack);
 
    // Make room for the new buffer.
    if(printIndex == numPrints)
@@ -1736,7 +1736,7 @@ uint32_t ACSVM::AddString(const char *s, uint32_t l)
       else
          string->script = NULL;
 
-      string->length = strlen(string->data.s);
+      string->length = static_cast<uint32_t>(strlen(string->data.s));
       string->number = GlobalNumStrings;
 
       // Make room in global array.
@@ -2414,7 +2414,7 @@ static SaveArchive &operator << (SaveArchive &arc, acs_call_t &call)
    uint32_t ipTemp;
 
    if(arc.isSaving())
-      ipTemp = call.ip - call.vm->code;
+      ipTemp = static_cast<uint32_t>(call.ip - call.vm->code);
 
    arc << ipTemp << call.numLocals << call.vm;
 
@@ -2556,17 +2556,17 @@ void ACSThinker::serialize(SaveArchive &arc)
    // Pointer-to-Index
    if(arc.isSaving())
    {
-      scriptIndex = script - vm->scripts;
+      scriptIndex = static_cast<uint32_t>(script - vm->scripts);
 
-      localsIndex = locals - localvar;
+      localsIndex = static_cast<uint32_t>(locals - localvar);
 
-      callPtrIndex = callPtr - calls;
+      callPtrIndex = static_cast<uint32_t>(callPtr - calls);
 
-      printIndex = printPtr - printStack;
+      printIndex = static_cast<uint32_t>(printPtr - printStack);
 
-      ipIndex = ip - vm->code;
+      ipIndex = static_cast<uint32_t>(ip - vm->code);
 
-      lineIndex = line ? line - lines + 1 : 0;
+      lineIndex = static_cast<uint32_t>(line ? line - lines + 1 : 0);
 
       triggerSwizzle = P_NumForThinker(trigger);
    }
@@ -2725,7 +2725,7 @@ void ACSVM::ArchiveStrings(SaveArchive &arc)
 
          // Set metadata.
          string->script = acsScriptsByName.objectForKey(string->data.s);
-         string->length = strlen(string->data.s);
+         string->length = static_cast<uint32_t>(strlen(string->data.s));
          string->number = GlobalNumStrings;
 
          // Add to global array.

--- a/source/acs_intr.h
+++ b/source/acs_intr.h
@@ -588,7 +588,7 @@ public:
       return strnum < GlobalNumStrings ? GlobalStrings[strnum] : NULL;
    }
 
-   static uint32_t AddString(const char *s) {return AddString(s, strlen(s));}
+   static uint32_t AddString(const char *s) {return AddString(s, static_cast<uint32_t>(strlen(s)));}
    static uint32_t AddString(const char *s, uint32_t l);
 
    static void ArchiveStrings(SaveArchive &arc);

--- a/source/c_cmd.cpp
+++ b/source/c_cmd.cpp
@@ -134,7 +134,7 @@ CONSOLE_COMMAND(cmdlist, 0)
    // letter
    if(Console.argc == 1)
    {
-      unsigned int len = Console.argv[0]->length();
+      unsigned int len = static_cast<unsigned>(Console.argv[0]->length());
 
       if(len == 1)
          charnum = maxchar = Console.argv[0]->charAt(0);

--- a/source/c_io.cpp
+++ b/source/c_io.cpp
@@ -685,7 +685,7 @@ static void C_AdjustLineBreaks(char *str)
 
    count = lastspace = 0;
 
-   len = strlen(str);
+   len = static_cast<int>(strlen(str));
 
    for(i = 0; i < len; ++i)
    {
@@ -816,7 +816,7 @@ void C_DumpMessages(qstring *filename)
    {
       // strip color codes from strings
       memset(tmpmessage, 0, LINELENGTH);
-      len = strlen(messages[i]);
+      len = static_cast<int>(strlen(messages[i]));
 
       C_StripColorChars((unsigned char *)messages[i], tmpmessage, len);
 
@@ -874,7 +874,7 @@ static void C_AppendToLog(const char *text)
       const unsigned char *src = (const unsigned char *)text;
 
       memset(tmpmessage, 0, 1024);
-      len = strlen(text);
+      len = static_cast<int>(strlen(text));
 
       C_StripColorChars(src, tmpmessage, len);
 

--- a/source/c_runcmd.cpp
+++ b/source/c_runcmd.cpp
@@ -869,7 +869,7 @@ static void C_SetVariable(command_t *command)
       
    case vt_string:
    case vt_chararray:
-      size = Console.argv[0]->length();
+      size = static_cast<int>(Console.argv[0]->length());
       break;
 
    case vt_float:

--- a/source/cam_sight.cpp
+++ b/source/cam_sight.cpp
@@ -376,7 +376,7 @@ static bool CAM_SightBlockLinesIterator(CamSight &cam, int x, int y)
    while(plink)
    {
       polyobj_t *po = (*plink)->po;
-      int polynum = po - PolyObjects;
+      int polynum = static_cast<int>(po - PolyObjects);
 
        // if polyobj hasn't been checked
       if(!(cam.validpolys[polynum >> 3] & (1 << (polynum & 7))))
@@ -385,12 +385,12 @@ static bool CAM_SightBlockLinesIterator(CamSight &cam, int x, int y)
          
          for(int i = 0; i < po->numLines; ++i)
          {
-            int linenum = po->lines[i] - lines;
+            int linenum = static_cast<int>(po->lines[i] - lines);
 
             if(cam.validlines[linenum >> 3] & (1 << (linenum & 7)))
                continue; // line has already been checked
 
-            if(!CAM_SightCheckLine(cam, po->lines[i] - lines))
+            if(!CAM_SightCheckLine(cam, static_cast<int>(po->lines[i] - lines)))
                return false;
          }
       }
@@ -689,8 +689,8 @@ bool CAM_CheckSight(const camsightparams_t &params)
    //
    // check for trivial rejection
    //
-   s1   = (csec = R_PointInSubsector(params.cx, params.cy)->sector) - sectors;
-   s2   = (tsec = R_PointInSubsector(params.tx, params.ty)->sector) - sectors;
+   s1   = static_cast<int>((csec = R_PointInSubsector(params.cx, params.cy)->sector) - sectors);
+   s2   = static_cast<int>((tsec = R_PointInSubsector(params.tx, params.ty)->sector) - sectors);
    pnum = s1 * numsectors + s2;
 	
    if(link || !(rejectmatrix[pnum >> 3] & (1 << (pnum & 7))))

--- a/source/d_deh.cpp
+++ b/source/d_deh.cpp
@@ -2377,7 +2377,7 @@ void deh_procBexSounds(DWFILE *fpin, char *line)
       // do it
       memset(candidate, 0, 9);
       strncpy(candidate, ptr_lstrip(strval), 9);
-      len = strlen(candidate);
+      len = static_cast<int>(strlen(candidate));
       if(len < 1 || len > 8)
       {
          deh_LogPrintf("Bad length for sound name '%s'\n", candidate);
@@ -2433,7 +2433,7 @@ void deh_procBexMusic(DWFILE *fpin, char *line)
       // do it
       memset(candidate, 0, 7);
       strncpy(candidate, ptr_lstrip(strval), 6);
-      len = strlen(candidate);
+      len = static_cast<int>(strlen(candidate));
       if(len < 1 || len > 6)
       {
          deh_LogPrintf("Bad length for music name '%s'\n", candidate);
@@ -2569,7 +2569,7 @@ bool deh_GetData(char *s, char *k, int *l, char **strval)
          okrc = false; 
 
       // we've incremented t
-      val = strtol(t, NULL, 0);  // killough 8/9/98: allow hex or octal input
+      val = static_cast<int>(strtol(t, NULL, 0));  // killough 8/9/98: allow hex or octal input
    }
 
    // go put the results in the passed pointers

--- a/source/d_io.cpp
+++ b/source/d_io.cpp
@@ -64,7 +64,7 @@ char *DWFILE::getStr(char *buf, size_t n)
 {
    // If this is a real file, return regular fgets
    if(type == DWF_FILE)
-      return fgets(buf, n, (FILE *)inp);
+      return fgets(buf, static_cast<int>(n), (FILE *)inp);
    
    // If no more characters
    if(!n || !*inp || size <= 0)

--- a/source/d_iwad.cpp
+++ b/source/d_iwad.cpp
@@ -471,7 +471,7 @@ static void D_DiskMetaData()
    if(!(slash = strrchr(wad.name, '\\')))
       return;
 
-   slen = slash - wad.name;
+   slen = static_cast<int>(slash - wad.name);
    ++slen;
    strncpy(name, wad.name, slen);
    strcpy(name + slen, "metadata.txt");

--- a/source/d_main.cpp
+++ b/source/d_main.cpp
@@ -486,13 +486,13 @@ static void D_showMemStats()
          psnprintf(buffer, sizeof(buffer), "%s%9lu %7.02f%%", 
                    cachelevels[i].name,
                    memorybytag[tag], memorybytag[tag] * s);
-         V_FontWriteText(font, buffer, 1, 1 + i*font->cy);
+         V_FontWriteText(font, buffer, 1, static_cast<int>(1 + i*font->cy));
       }
       else
       {
          psnprintf(buffer, sizeof(buffer), "%s%9lu %7.02f%%",
                    cachelevels[i].name, total_memory, 100.0f);
-         V_FontWriteText(font, buffer, 1, 1 + i*font->cy);
+         V_FontWriteText(font, buffer, 1, static_cast<int>(1 + i*font->cy));
       }
    }
 }
@@ -779,7 +779,7 @@ void D_SetGameName(const char *iwad)
       // joel 10/16/98 Final DOOM fix
       if(GameModeInfo->missionInfo->id == doom2)
       {
-         int i = strlen(iwad);
+         int i = static_cast<int>(strlen(iwad));
          if(i >= 10 && !strncasecmp(iwad+i-10, "doom2f.wad", 10))
          {
             language = french;

--- a/source/e_args.cpp
+++ b/source/e_args.cpp
@@ -767,7 +767,7 @@ int E_ArgAsBexptr(arglist_t *al, int index)
       deh_bexptr *ptr = D_GetBexPtr(al->args[index]);
 
       eval->type    = EVALTYPE_BEXPTR;
-      eval->value.i = ptr ? ptr - deh_bexptrs : -1;
+      eval->value.i = static_cast<int>(ptr ? ptr - deh_bexptrs : -1);
    }
 
    return eval->value.i;

--- a/source/e_exdata.cpp
+++ b/source/e_exdata.cpp
@@ -323,7 +323,7 @@ static cfg_opt_t ed_opts[] =
 static void E_ParseArg(const char *str, int *dest)
 {
    // currently only integers are supported
-   *dest = strtol(str, NULL, 0);
+   *dest = static_cast<int>(strtol(str, NULL, 0));
 }
 
 //=============================================================================
@@ -1038,7 +1038,7 @@ static int E_LineSpecCB(cfg_t *cfg, cfg_opt_t *opt, const char *value,
    int  num;
    char *endptr;
 
-   num = strtol(value, &endptr, 0);
+   num = static_cast<int>(strtol(value, &endptr, 0));
 
    // check if value is a number or not
    if(*endptr != '\0')

--- a/source/e_fonts.cpp
+++ b/source/e_fonts.cpp
@@ -595,7 +595,7 @@ static void E_ProcessFontFilter(cfg_t *sec, vfontfilter_t *f)
          tempstr = cfg_getnstr(sec, ITEM_FILTER_CHARS, i);
 
          if(strlen(tempstr) > 1)
-            tempnum = strtol(tempstr, &pos, 0);
+            tempnum = static_cast<int>(strtol(tempstr, &pos, 0));
 
          if(pos && *pos == '\0')
             f->chars[i] = tempnum;
@@ -610,7 +610,7 @@ static void E_ProcessFontFilter(cfg_t *sec, vfontfilter_t *f)
       tempstr = cfg_getstr(sec, ITEM_FILTER_START);
       
       if(strlen(tempstr) > 1)
-         tempnum = strtol(tempstr, &pos, 0);
+         tempnum = static_cast<int>(strtol(tempstr, &pos, 0));
 
       if(pos && *pos == '\0') // is it a number?
          f->start = tempnum;
@@ -621,7 +621,7 @@ static void E_ProcessFontFilter(cfg_t *sec, vfontfilter_t *f)
       tempstr = cfg_getstr(sec, ITEM_FILTER_END);
       
       if(strlen(tempstr) > 1)
-         tempnum = strtol(tempstr, &pos, 0);
+         tempnum = static_cast<int>(strtol(tempstr, &pos, 0));
 
       if(pos && *pos == '\0') // is it a number?
          f->end = tempnum;
@@ -790,7 +790,7 @@ static void E_ProcessFont(cfg_t *sec)
       tempstr = cfg_getstr(sec, ITEM_FONT_START);
 
       if(strlen(tempstr) > 1)
-         tempnum = strtol(tempstr, &pos, 0);
+         tempnum = static_cast<int>(strtol(tempstr, &pos, 0));
 
       if(pos && *pos == '\0') // it is a number?
          font->start = tempnum; 
@@ -805,7 +805,7 @@ static void E_ProcessFont(cfg_t *sec)
       tempstr = cfg_getstr(sec, ITEM_FONT_END);
 
       if(strlen(tempstr) > 1)
-         tempnum = strtol(tempstr, &pos, 0);
+         tempnum = static_cast<int>(strtol(tempstr, &pos, 0));
 
       if(pos && *pos == '\0') // is it a number?
          font->end = tempnum;

--- a/source/e_lib.cpp
+++ b/source/e_lib.cpp
@@ -557,7 +557,7 @@ int E_SpriteFrameCB(cfg_t *cfg, cfg_opt_t *opt, const char *value,
    {
       char *endptr;
 
-      *(int *)result = strtol(value, &endptr, 0);
+      *(int *)result = static_cast<int>(strtol(value, &endptr, 0));
       
       if(*endptr != '\0')
       {
@@ -677,7 +677,7 @@ int E_TranslucCB(cfg_t *cfg, cfg_opt_t *opt, const char *value,
       int pctvalue;
       
       // get the percentage value (base 10 only)
-      pctvalue = strtol(value, &endptr, 10);
+      pctvalue = static_cast<int>(strtol(value, &endptr, 10));
 
       // strtol should stop at the percentage sign
       if(endptr != pctloc)
@@ -749,7 +749,7 @@ int E_TranslucCB2(cfg_t *cfg, cfg_opt_t *opt, const char *value,
       int pctvalue;
       
       // get the percentage value (base 10 only)
-      pctvalue = strtol(value, &endptr, 10);
+      pctvalue = static_cast<int>(strtol(value, &endptr, 10));
 
       // strtol should stop at the percentage sign
       if(endptr != pctloc)

--- a/source/e_sound.cpp
+++ b/source/e_sound.cpp
@@ -1172,7 +1172,7 @@ inline static sfxinfo_t *E_SeqGetSound(const char *soundname)
 //
 inline static int E_SeqGetNumber(const char *numstr)
 {
-   return numstr ? strtol(numstr, NULL, 0) : 0;
+   return static_cast<int>(numstr ? strtol(numstr, NULL, 0) : 0);
 }
 
 //

--- a/source/e_states.cpp
+++ b/source/e_states.cpp
@@ -658,7 +658,7 @@ static void E_AssignMiscBexptr(int *target, deh_bexptr *dp, const char *name)
    
    // get the index of this deh_bexptr in the master
    // deh_bexptrs array, and store it in the arg field
-   *target = dp - deh_bexptrs;
+   *target = static_cast<int>(dp - deh_bexptrs);
 }
 
 //
@@ -776,7 +776,7 @@ static void E_ParseMiscField(const char *value, int *target)
       else
       {
          // 11/11/03: use strtol to support hex and oct input
-         val = strtol(value, &endptr, 0);
+         val = static_cast<int>(strtol(value, &endptr, 0));
       }
 
       // haleyjd 04/02/08:
@@ -1110,7 +1110,7 @@ static void E_ProcessCmpState(const char *value, int i)
    if(DEFAULTS(curtoken))
       states[i]->tics = 1;
    else
-      states[i]->tics = strtol(curtoken, NULL, 0);
+      states[i]->tics = static_cast<int>(strtol(curtoken, NULL, 0));
 
    // process action
    in_action = true;

--- a/source/e_things.cpp
+++ b/source/e_things.cpp
@@ -1608,7 +1608,7 @@ static int E_ColorCB(cfg_t *cfg, cfg_opt_t *opt, const char *value,
    int num;
    char *endptr;
 
-   num = strtol(value, &endptr, 0);
+   num = static_cast<int>(strtol(value, &endptr, 0));
 
    // try lump name
    if(*endptr != '\0')
@@ -2386,7 +2386,7 @@ void E_ProcessThing(int i, cfg_t *thingsec, cfg_t *pcfg, bool def)
       char *endpos = NULL;
       tempstr = cfg_getstr(thingsec, ITEM_TNG_MOD);
 
-      tempint = strtol(tempstr, &endpos, 0);
+      tempint = static_cast<int>(strtol(tempstr, &endpos, 0));
       
       if(endpos && *endpos == '\0')
          mod = E_DamageTypeForNum(tempint);  // it is a number

--- a/source/e_weapons.cpp
+++ b/source/e_weapons.cpp
@@ -74,6 +74,7 @@ static dehflags_t e_weaponFlags[] =
    { NULL,           0                }
 };
 
+// FIXME: (IOANCH 20151212) unused
 static dehflagset_t e_weaponFlagSet =
 {
    e_weaponFlags, // flags

--- a/source/ev_sectors.cpp
+++ b/source/ev_sectors.cpp
@@ -295,7 +295,7 @@ static void EV_SectorHticScrollEastLavaDamage(sector_t *sector)
    sector->hticPushForce = 2048*28;
    
    // scrolls to the east:
-   Add_Scroller(ScrollThinker::sc_floor, (-FRACUNIT/2)<<3, 0, -1, sector - sectors, 0);
+   Add_Scroller(ScrollThinker::sc_floor, (-FRACUNIT/2)<<3, 0, -1, static_cast<int>(sector - sectors), 0);
 }
 
 //
@@ -375,7 +375,7 @@ static void EV_setupHereticPusher(sector_t *sector, angle_t angle, int type, int
 static void EV_setupHereticScroller(sector_t *sector, int force)
 {
    Add_Scroller(ScrollThinker::sc_floor, (-FRACUNIT/2) << force,
-                0, -1, sector-sectors, 0);
+                0, -1, static_cast<int>(sector-sectors), 0);
 }
 
 //

--- a/source/g_game.cpp
+++ b/source/g_game.cpp
@@ -1337,7 +1337,7 @@ static void G_ReadDemoTiccmd(ticcmd_t *cmd)
 //
 static void G_WriteDemoTiccmd(ticcmd_t *cmd)
 {
-   unsigned int position = demo_p - demobuffer;
+   unsigned int position = static_cast<unsigned>(demo_p - demobuffer);
    int i = 0;
    
    demo_p[i++] = cmd->forwardmove;
@@ -2368,7 +2368,7 @@ static bool G_CheckSpot(int playernum, mapthing_t *mthing, Mobj **fog)
 //
 int G_ClosestDMSpot(fixed_t x, fixed_t y, int notspot)
 {
-   int j, numspots = deathmatch_p - deathmatchstarts;
+   int j, numspots = static_cast<int>(deathmatch_p - deathmatchstarts);
    int closestspot = -1;
    fixed_t closestdist = 32767*FRACUNIT;
 
@@ -2400,7 +2400,7 @@ extern const char *level_error;
 //
 void G_DeathMatchSpawnPlayer(int playernum)
 {
-   int j, selections = deathmatch_p - deathmatchstarts;
+   int j, selections = static_cast<int>(deathmatch_p - deathmatchstarts);
    Mobj *fog = NULL;
    
    if(selections < MAXPLAYERS)

--- a/source/m_misc.cpp
+++ b/source/m_misc.cpp
@@ -1013,7 +1013,7 @@ static void M_setDefaultValueString(default_t *dp, void *value, bool wad)
 // Read a string option and set it
 static bool M_readDefaultString(default_t *dp, char *src, bool wad)
 {
-   int len = strlen(src) - 1;
+   int len = static_cast<int>(strlen(src) - 1);
 
    while(ectype::isSpace(src[len]))
       len--;
@@ -1778,7 +1778,7 @@ int M_ReadFile(char const *name, byte **buffer)
       if(fread(*buffer, 1, length, fp) == length)
       {
          fclose(fp);
-         return length;
+         return static_cast<int>(length);
       }
       fclose(fp);
    }
@@ -2140,7 +2140,7 @@ int M_StringAlloca(char **str, int numstrs, size_t extra, const char *str1, ...)
 
    *str = (char *)(Z_Alloca(len));
 
-   return len;
+   return static_cast<int>(len);
 }
 
 //

--- a/source/m_qstr.cpp
+++ b/source/m_qstr.cpp
@@ -1399,7 +1399,7 @@ void qstring::archive(SaveArchive &arc)
    arc.ArchiveLString(buffer, size);
 
    if(arc.isSaving())
-      indexTemp = index;
+      indexTemp = static_cast<uint32_t>(index);
 
    arc << indexTemp;
 

--- a/source/mn_menus.cpp
+++ b/source/mn_menus.cpp
@@ -1279,7 +1279,7 @@ patch_t *patch_left, *patch_mid, *patch_right;
 void MN_SaveGame()
 {
    int save_slot = 
-      (char **)(Console.command->variable->variable) - savegamenames;
+      static_cast<int>((char **)(Console.command->variable->variable) - savegamenames);
    
    if(gamestate != GS_LEVEL) 
       return; // only save in level

--- a/source/p_floor.cpp
+++ b/source/p_floor.cpp
@@ -602,7 +602,7 @@ int EV_DoFloor(const line_t *line, floor_e floortype )
 
          //jff 5/23/98 use model subroutine to unify fixes and handling
          sec = P_FindModelFloorSector(floor->floordestheight,
-                                      sec-sectors);
+                                      static_cast<int>(sec-sectors));
          if(sec)
          {
             floor->texture = sec->floorpic;
@@ -795,14 +795,14 @@ int EV_BuildStairs(const line_t *line, stair_e type)
                if(!((sec->lines[i])->flags & ML_TWOSIDED))
                   continue;
 
-               newsecnum = tsec-sectors;
+               newsecnum = static_cast<int>(tsec-sectors);
                
                if(secnum != newsecnum)
                   continue;
                
                tsec = (sec->lines[i])->backsector;
                if(!tsec) continue;     //jff 5/7/98 if no backside, continue
-               newsecnum = tsec - sectors;
+               newsecnum = static_cast<int>(tsec - sectors);
 
                // if sector's floor is different texture, look for another
                if(tsec->floorpic != texture)
@@ -1134,7 +1134,7 @@ int EV_PillarBuild(const line_t *line, const pillardata_t *pd)
    {
       if(!line || !(sector = line->backsector))
          return returnval;
-      sectornum = sector - sectors;
+      sectornum = static_cast<int>(sector - sectors);
       manual = true;
       goto manual_pillar;
    }
@@ -1223,7 +1223,7 @@ int EV_PillarOpen(const line_t *line, const pillardata_t *pd)
    {
       if(!line || !(sector = line->backsector))
          return returnval;
-      sectornum = sector - sectors;
+      sectornum = static_cast<int>(sector - sectors);
       manual = true;
       goto manual_pillar;
    }
@@ -1397,7 +1397,7 @@ int EV_StartFloorWaggle(const line_t *line, int tag, int height, int speed,
    {
       if(!line || !(sector = line->backsector))
          return retCode;
-      sectorIndex = sector - sectors;
+      sectorIndex = static_cast<int>(sector - sectors);
       manual = true;
       goto manual_waggle;
    }

--- a/source/p_genlin.cpp
+++ b/source/p_genlin.cpp
@@ -71,7 +71,7 @@ int EV_DoParamFloor(const line_t *line, int tag, const floordata_t *fd)
    {
       if(!line || !(sec = line->backsector))
          return rtn;
-      secnum = sec - sectors;
+      secnum = static_cast<int>(sec - sectors);
       manual = true;
       goto manual_floor;
    }
@@ -326,7 +326,7 @@ int EV_DoParamCeiling(const line_t *line, int tag, const ceilingdata_t *cd)
    {
       if(!line || !(sec = line->backsector))
          return rtn;
-      secnum = sec - sectors;
+      secnum = static_cast<int>(sec - sectors);
       manual = true;
       goto manual_ceiling;
    }
@@ -594,7 +594,7 @@ int EV_DoGenLift(const line_t *line)
    {
       if (!(sec = line->backsector))
          return rtn;
-      secnum = sec - sectors;
+      secnum = static_cast<int>(sec - sectors);
       manual = true;
       goto manual_lift;
    }
@@ -739,7 +739,7 @@ int EV_DoParamStairs(const line_t *line, int tag, const stairdata_t *sd)
    {
       if(!line || !(sec = line->backsector))
          return rtn;
-      secnum = sec - sectors;
+      secnum = static_cast<int>(sec - sectors);
       manual = true;
       goto manual_stair;
    }
@@ -852,13 +852,13 @@ manual_stair:
                continue;
             
             tsec = (sec->lines[i])->frontsector;
-            newsecnum = tsec-sectors;
+            newsecnum = static_cast<int>(tsec-sectors);
             
             if(secnum != newsecnum)
                continue;
             
             tsec = (sec->lines[i])->backsector;
-            newsecnum = tsec - sectors;
+            newsecnum = static_cast<int>(tsec - sectors);
             
             if(!(sd->flags & SDF_IGNORETEXTURES) && tsec->floorpic != texture)
                continue;
@@ -1002,7 +1002,7 @@ int EV_DoGenCrusher(const line_t *line)
    {
       if(!(sec = line->backsector))
          return rtn;
-      secnum = sec-sectors;
+      secnum = static_cast<int>(sec-sectors);
       manual = true;
       goto manual_crusher;
    }
@@ -1141,7 +1141,7 @@ int EV_DoParamDoor(const line_t *line, int tag, const doordata_t *dd)
    {
       if(!line || !(sec = line->backsector))
          return rtn;
-      secnum = sec - sectors;
+      secnum = static_cast<int>(sec - sectors);
       manual = true;
       goto manual_door;
    }

--- a/source/p_info.cpp
+++ b/source/p_info.cpp
@@ -325,7 +325,7 @@ void P_AddMusInfoMusic(const char *mapname, int number, const char *lump)
    // Does it exist already?
    if((music = musInfoMusHash.objectForKey(mapname)))
    {
-      int nummaps = music->maps.getLength();
+      int nummaps = static_cast<int>(music->maps.getLength());
       bool foundnum = false;
 
       // Does it have an entry for this number already?

--- a/source/p_lights.cpp
+++ b/source/p_lights.cpp
@@ -855,7 +855,7 @@ int EV_SetLight(const line_t *line, int tag, setlight_e type, int lvl)
    {
       if(!line->backsector)
          return rtn;
-      i = line->backsector - sectors;
+      i = static_cast<int>(line->backsector - sectors);
       backside = true;
       goto dobackside;
    }
@@ -914,7 +914,7 @@ int EV_FadeLight(const line_t *line, int tag, int destvalue, int speed)
    {
       if(!line->backsector)
          return rtn;
-      i = line->backsector - sectors;
+      i = static_cast<int>(line->backsector - sectors);
       backside = true;
       goto dobackside;
    }
@@ -974,7 +974,7 @@ int EV_GlowLight(const line_t *line, int tag, int maxval, int minval, int speed)
    {
       if(!line->backsector)
          return rtn;
-      i = line->backsector - sectors;
+      i = static_cast<int>(line->backsector - sectors);
       backside = true;
       goto dobackside;
    }
@@ -1027,7 +1027,7 @@ int EV_StrobeLight(const line_t *line, int tag,
    {
       if(!line->backsector)
          return rtn;
-      i = line->backsector - sectors;
+      i = static_cast<int>(line->backsector - sectors);
       backside = true;
       goto dobackside;
    }
@@ -1073,7 +1073,7 @@ int EV_FlickerLight(const line_t *line, int tag, int maxval, int minval)
    {
       if(!line->backsector)
          return rtn;
-      i = line->backsector - sectors;
+      i = static_cast<int>(line->backsector - sectors);
       backside = true;
       goto dobackside;
    }

--- a/source/p_map.cpp
+++ b/source/p_map.cpp
@@ -607,7 +607,7 @@ static void SpechitOverrun(line_t *ld)
    // the offset of the line in the array times the original structure size to
    // reconstruct the approximate line addresses actually written. In most cases
    // this doesn't matter because of the nature of tmbbox, however.
-   addr = baseaddr + (ld - lines) * 0x3E;
+   addr = static_cast<unsigned>(baseaddr + (ld - lines) * 0x3E);
 
    // Note: only the variables affected up to 20 are known, and it is of no
    // consequence to alter any of the variables between 15 and 20 because they

--- a/source/p_map3d.cpp
+++ b/source/p_map3d.cpp
@@ -991,7 +991,7 @@ static bool midtex_moving;
 //
 static int P_PushUp(Mobj *thing)
 {
-   unsigned int firstintersect = intersectors.getLength();
+   unsigned int firstintersect = static_cast<unsigned>(intersectors.getLength());
    unsigned int lastintersect;
    int mymass = thing->info->mass;
 
@@ -999,7 +999,7 @@ static int P_PushUp(Mobj *thing)
       return 1;
 
    P_FindAboveIntersectors(thing);
-   lastintersect = intersectors.getLength();
+   lastintersect = static_cast<unsigned>(intersectors.getLength());
    for(; firstintersect < lastintersect; ++firstintersect)
    {
       Mobj *intersect = intersectors[firstintersect];
@@ -1035,7 +1035,7 @@ static int P_PushUp(Mobj *thing)
 //
 static int P_PushDown(Mobj *thing)
 {
-   unsigned int firstintersect = intersectors.getLength();
+   unsigned int firstintersect = static_cast<unsigned>(intersectors.getLength());
    unsigned int lastintersect;
    int mymass = thing->info->mass;
 
@@ -1043,7 +1043,7 @@ static int P_PushDown(Mobj *thing)
       return 1;
 
    P_FindBelowIntersectors(thing);
-   lastintersect = intersectors.getLength();
+   lastintersect = static_cast<unsigned>(intersectors.getLength());
    for(; firstintersect < lastintersect; ++firstintersect)
    {
       Mobj *intersect = intersectors[firstintersect];

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -1489,7 +1489,7 @@ void Mobj::serialize(SaveArchive &arc)
 
       // Basic serializable pointers (state, player)
       arc << state->index;
-      temp = player ? player - players + 1 : 0;
+      temp = static_cast<unsigned>(player ? player - players + 1 : 0);
       arc << temp;
 
       // Pointers to other mobjs

--- a/source/p_partcl.cpp
+++ b/source/p_partcl.cpp
@@ -410,7 +410,7 @@ void P_ParticleThinker(void)
             else
                activeParticles = i;
             particle->next = inactiveParticles;
-            inactiveParticles = particle - Particles;
+            inactiveParticles = static_cast<int>(particle - Particles);
             continue;
          }
       }
@@ -484,12 +484,12 @@ void P_RunEffects(void)
    if(camera)
    {
       subsector_t *ss = R_PointInSubsector(camera->x, camera->y);
-      snum = (ss->sector - sectors) * numsectors;
+      snum = static_cast<int>((ss->sector - sectors) * numsectors);
    }
    else
    {
       subsector_t *ss = players[displayplayer].mo->subsector;
-      snum = (ss->sector - sectors) * numsectors;
+      snum = static_cast<int>((ss->sector - sectors) * numsectors);
    }
 
    while((th = th->next) != &thinkercap)
@@ -497,7 +497,7 @@ void P_RunEffects(void)
       Mobj *mobj;
       if((mobj = thinker_cast<Mobj *>(th)))
       {
-         int rnum = snum + (mobj->subsector->sector - sectors);
+         int rnum = static_cast<int>(snum + (mobj->subsector->sector - sectors));
          if(mobj->effects)
          {
             // run only if possibly visible

--- a/source/p_plats.cpp
+++ b/source/p_plats.cpp
@@ -421,7 +421,7 @@ bool EV_DoParamPlat(const line_t *line, const int *args, paramplattype_e type)
       if(!line || !line->backsector)
          return false;
       sec    = line->backsector;
-      secnum = sec - sectors;
+      secnum = static_cast<int>(sec - sectors);
       manual = true;
       goto manual_plat;
    }

--- a/source/p_portal.cpp
+++ b/source/p_portal.cpp
@@ -365,7 +365,7 @@ int P_AddLinkOffset(int startgroup, int targetgroup,
 //
 static bool P_CheckLinkedPortal(portal_t *portal, sector_t *sec)
 {
-   int i = sec - sectors;
+   int i = static_cast<int>(sec - sectors);
 
    if(!portal || !sec)
       return true;
@@ -664,7 +664,7 @@ void P_LinkRejectTable()
       list = groups[i]->seclist;
       for(s = 0; list[s]; s++)
       {
-         int sectorindex1 = list[s] - sectors;
+         int sectorindex1 = static_cast<int>(list[s] - sectors);
 
          for(p = 0; p < groupcount; p++)
          {
@@ -674,7 +674,7 @@ void P_LinkRejectTable()
             list2 = groups[p]->seclist;
             for(q = 0; list2[q]; q++)
             {
-               int sectorindex2 = list2[q] - sectors;
+               int sectorindex2 = static_cast<int>(list2[q] - sectors);
                int pnum = (sectorindex1 * numsectors) + sectorindex2;
 
                rejectmatrix[pnum>>3] &= ~(1 << (pnum&7));

--- a/source/p_saveg.cpp
+++ b/source/p_saveg.cpp
@@ -278,7 +278,7 @@ SaveArchive &SaveArchive::operator << (sector_t *&s)
 
    if(savefile)
    {
-      sectornum = s - sectors;
+      sectornum = static_cast<int32_t>(s - sectors);
       savefile->WriteSint32(sectornum);
    }
    else
@@ -303,7 +303,7 @@ SaveArchive &SaveArchive::operator << (line_t *&ln)
    if(savefile)
    {
       if(ln)
-         linenum = ln - lines;
+         linenum = static_cast<int32_t>(ln - lines);
       savefile->WriteSint32(linenum);
    }
    else
@@ -1031,7 +1031,7 @@ static void P_ArchiveSndSeq(SaveArchive &arc, SndSeq_t *seq)
    arc.ArchiveCString(seq->sequence->name, 33);
 
    // twizzle command pointer
-   twizzle = seq->cmdPtr - seq->sequence->commands;
+   twizzle = static_cast<unsigned>(seq->cmdPtr - seq->sequence->commands);
    arc << twizzle;
 
    // save origin type

--- a/source/p_scroll.cpp
+++ b/source/p_scroll.cpp
@@ -249,7 +249,7 @@ static void P_spawnCeilingScroller(int staticFn, line_t *l)
       accel = 1;
    if(staticFn == EV_STATIC_SCROLL_ACCEL_CEILING ||
       staticFn == EV_STATIC_SCROLL_DISPLACE_CEILING)
-      control = sides[*l->sidenum].sector - sectors;
+      control = static_cast<int>(sides[*l->sidenum].sector - sectors);
 
    for(int s = -1; (s = P_FindSectorFromLineTag(l, s)) >= 0;)
       Add_Scroller(ScrollThinker::sc_ceiling, -dx, dy, control, s, accel);
@@ -275,7 +275,7 @@ static void P_spawnFloorScroller(int staticFn, line_t *l)
       accel = 1;
    if(staticFn == EV_STATIC_SCROLL_ACCEL_FLOOR ||
       staticFn == EV_STATIC_SCROLL_DISPLACE_FLOOR)
-      control = sides[*l->sidenum].sector - sectors;
+      control = static_cast<int>(sides[*l->sidenum].sector - sectors);
 
    for(int s = -1; (s = P_FindSectorFromLineTag(l, s)) >= 0;)
       Add_Scroller(ScrollThinker::sc_floor, -dx, dy, control, s, accel);
@@ -301,7 +301,7 @@ static void P_spawnFloorCarrier(int staticFn, line_t *l)
       accel = 1;
    if(staticFn == EV_STATIC_CARRY_ACCEL_FLOOR ||
       staticFn == EV_STATIC_CARRY_DISPLACE_FLOOR)
-      control = sides[*l->sidenum].sector - sectors;
+      control = static_cast<int>(sides[*l->sidenum].sector - sectors);
 
    for(int s = -1; (s = P_FindSectorFromLineTag(l, s)) >= 0;)
       Add_Scroller(ScrollThinker::sc_carry, dx, dy, control, s, accel);
@@ -328,7 +328,7 @@ static void P_spawnFloorScrollAndCarry(int staticFn, line_t *l)
       accel = 1;
    if(staticFn == EV_STATIC_SCROLL_CARRY_ACCEL_FLOOR ||
       staticFn == EV_STATIC_SCROLL_CARRY_DISPLACE_FLOOR)
-      control = sides[*l->sidenum].sector - sectors;
+      control = static_cast<int>(sides[*l->sidenum].sector - sectors);
 
    for(s = -1; (s = P_FindSectorFromLineTag(l, s)) >= 0; )
       Add_Scroller(ScrollThinker::sc_floor, -dx, dy, control, s, accel);
@@ -363,7 +363,7 @@ static void P_spawnDynamicWallScroller(int staticFn, line_t *l, int linenum)
       accel = 1;
    if(staticFn == EV_STATIC_SCROLL_ACCEL_WALL ||
       staticFn == EV_STATIC_SCROLL_DISPLACE_WALL)
-      control = sides[*l->sidenum].sector - sectors;
+      control = static_cast<int>(sides[*l->sidenum].sector - sectors);
 
    // killough 3/1/98: scroll wall according to linedef
    // (same direction and speed as scrolling floors)

--- a/source/p_sight.cpp
+++ b/source/p_sight.cpp
@@ -351,7 +351,7 @@ bool P_CheckSight(Mobj *t1, Mobj *t2)
 
    const sector_t *s1 = t1->subsector->sector;
    const sector_t *s2 = t2->subsector->sector;
-   int pnum = (s1-sectors)*numsectors + (s2-sectors);
+   int pnum = static_cast<int>((s1-sectors)*numsectors + (s2-sectors));
    los_t los;
 
    // First check for trivial rejection.

--- a/source/p_skin.cpp
+++ b/source/p_skin.cpp
@@ -157,7 +157,7 @@ void P_InitSkins(void)
       if(!skins[i]->edfskin)
       {
          *currentsprite   = skins[i]->spritename;
-         skins[i]->sprite = currentsprite - spritelist;
+         skins[i]->sprite = static_cast<spritenum_t>(currentsprite - spritelist);
          currentsprite++;
       }
       P_ResolveSkinSounds(skins[i]); // haleyjd 10/17/05: resolve sounds
@@ -219,7 +219,7 @@ static void P_AddSkin(skin_t *newskin)
 
 static void P_AddSpriteLumps(const char *named)
 {
-   int i, n = strlen(named);
+   int i, n = static_cast<int>(strlen(named));
    int numlumps = wGlobalDir.getNumLumps();
    lumpinfo_t **lumpinfo = wGlobalDir.getLumpInfo();
    

--- a/source/p_spec.cpp
+++ b/source/p_spec.cpp
@@ -1244,14 +1244,14 @@ void P_SpawnSpecials()
          // killough 3/7/98:
          // support for drawn heights coming from different sector
       case EV_STATIC_TRANSFER_HEIGHTS:
-         sec = sides[*lines[i].sidenum].sector-sectors;
+         sec = static_cast<int>(sides[*lines[i].sidenum].sector-sectors);
          P_SetupHeightTransfer(i, sec); // haleyjd 03/04/07
          break;
 
          // killough 3/16/98: Add support for setting
          // floor lighting independently (e.g. lava)
       case EV_STATIC_LIGHT_TRANSFER_FLOOR:
-         sec = sides[*lines[i].sidenum].sector-sectors;
+         sec = static_cast<int>(sides[*lines[i].sidenum].sector-sectors);
          for(s = -1; (s = P_FindSectorFromLineTag(lines+i,s)) >= 0;)
             sectors[s].floorlightsec = sec;
          break;
@@ -1259,7 +1259,7 @@ void P_SpawnSpecials()
          // killough 4/11/98: Add support for setting
          // ceiling lighting independently
       case EV_STATIC_LIGHT_TRANSFER_CEILING:
-         sec = sides[*lines[i].sidenum].sector-sectors;
+         sec = static_cast<int>(sides[*lines[i].sidenum].sector-sectors);
          for(s = -1; (s = P_FindSectorFromLineTag(lines+i,s)) >= 0;)
             sectors[s].ceilinglightsec = sec;
          break;
@@ -1694,7 +1694,7 @@ void P_SetLineID(line_t *line, int id)
       int chain = (unsigned int)line->tag % (unsigned int)numlines; // Hash func
    
       line->nexttag = lines[chain].firsttag;   // Prepend linedef to chain
-      lines[chain].firsttag = line - lines;
+      lines[chain].firsttag = static_cast<int>(line - lines);
    }
 }
 
@@ -1960,7 +1960,7 @@ void P_AttachLines(const line_t *cline, bool ceiling)
               attached = erealloc(int *, attached, sizeof(int) * maxattach);
             }
 
-            attached[numattach++] = line - lines;
+            attached[numattach++] = static_cast<int>(line - lines);
          }
          
          // SoM 12/8/02: Don't attach the backsector.
@@ -1996,8 +1996,8 @@ void P_AttachLines(const line_t *cline, bool ceiling)
    numattach = 0;
    for(start = 0; start < alistsize; ++start)
    {
-      int front = lines[alist[start]].frontsector - sectors;
-      int back  = lines[alist[start]].backsector - sectors;
+      int front = static_cast<int>(lines[alist[start]].frontsector - sectors);
+      int back  = static_cast<int>(lines[alist[start]].backsector - sectors);
 
       // Check the frontsector for uniqueness in the list.
       for(i = 0; i < numattach; ++i)
@@ -2496,7 +2496,7 @@ static void P_SpawnPortal(line_t *line, int staticFn)
          return;
       }
 
-      portal = R_GetAnchoredPortal(line - lines, s);
+      portal = R_GetAnchoredPortal(static_cast<int>(line - lines), s);
       break;
 
    case portal_twoway:
@@ -2524,7 +2524,7 @@ static void P_SpawnPortal(line_t *line, int staticFn)
          return;
       }
 
-      portal = R_GetTwoWayPortal(line - lines, s);
+      portal = R_GetTwoWayPortal(static_cast<int>(line - lines), s);
       break;
 
    case portal_linked:
@@ -2581,14 +2581,14 @@ static void P_SpawnPortal(line_t *line, int staticFn)
       toid = sector->groupid;
       fromid = lines[s].frontsector->groupid;
             
-      portal = R_GetLinkedPortal(line - lines, s, planez, fromid, toid);
+      portal = R_GetLinkedPortal(static_cast<int>(line - lines), s, planez, fromid, toid);
 
       // Special case where the portal was created with the line-to-line portal type
       if(staticFn == EV_STATIC_PORTAL_LINKED_LINE2LINE)
       {
          P_SetPortal(lines[s].frontsector, lines + s, portal, portal_lineonly);
          
-         portal = R_GetLinkedPortal(s, line - lines, planez, toid, fromid);
+         portal = R_GetLinkedPortal(s, static_cast<int>(line - lines), planez, toid, fromid);
          P_SetPortal(sector, line, portal, portal_lineonly);
          return;
       }

--- a/source/p_switch.cpp
+++ b/source/p_switch.cpp
@@ -184,7 +184,7 @@ static void P_StartButton(int sidenum, line_t *line, sector_t *sector,
 
    button = P_FindFreeButton();
    
-   button->line     = line - lines;
+   button->line     = static_cast<int>(line - lines);
    button->side     = sidenum;
    button->where    = w;
    button->btexture = texture;

--- a/source/p_trace.cpp
+++ b/source/p_trace.cpp
@@ -794,7 +794,7 @@ bool PIT_AddThingIntercepts(Mobj *thing)
 bool P_TraverseIntercepts(traverser_t func, fixed_t maxfrac)
 {
    intercept_t *in = nullptr;
-   int count = intercept_p - intercepts;
+   int count = static_cast<int>(intercept_p - intercepts);
    while(count--)
    {
       fixed_t dist = D_MAXINT;

--- a/source/psnprntf.cpp
+++ b/source/psnprntf.cpp
@@ -384,9 +384,9 @@ int pvsnfmt_str(pvsnfmt_vars *info, const char *s)
 
     /* Truncate due to precision */
     if (info->precision < 0)
-        len = strlen(str);
+        len = static_cast<int>(strlen(str));
     else
-        len = pstrnlen(str, info->precision);
+        len = static_cast<int>(pstrnlen(str, info->precision));
 
     /* Determine padding length */
     if (width > len)
@@ -406,7 +406,7 @@ int pvsnfmt_str(pvsnfmt_vars *info, const char *s)
             padchar = ' ';
 
         if ((int) info->nmax - 1 < pad)
-            nprinted = info->nmax - 1;
+            nprinted = static_cast<int>(info->nmax - 1);
         else
             nprinted = pad;
 
@@ -419,7 +419,7 @@ int pvsnfmt_str(pvsnfmt_vars *info, const char *s)
     if (info->nmax <= 1)
         nprinted = 0;
     else if ((int) info->nmax - 1 < len)
-        nprinted = info->nmax - 1;
+        nprinted = static_cast<int>(info->nmax - 1);
     else
         nprinted = len;
 
@@ -433,7 +433,7 @@ int pvsnfmt_str(pvsnfmt_vars *info, const char *s)
         if (info->nmax <= 1)
             nprinted = 0;
         else if ((int)info->nmax - 1 < pad)
-            nprinted = info->nmax - 1;
+            nprinted = static_cast<int>(info->nmax - 1);
         else
             nprinted = pad;
 
@@ -692,7 +692,7 @@ int pvsnfmt_int(pvsnfmt_vars *info, pvsnfmt_intparm_t *ip)
         if (info->nmax <= 1)
             widthpad = 0;
         else if ((int) info->nmax - 1 < widthpad)
-            widthpad = info->nmax - 1;
+            widthpad = static_cast<int>(info->nmax - 1);
 
         if (flags & FLAG_ZERO_PAD)
             memset(info->pinsertion, '0', widthpad);
@@ -737,7 +737,7 @@ int pvsnfmt_int(pvsnfmt_vars *info, pvsnfmt_intparm_t *ip)
     if (info->nmax <= 1)
         len = 0;
     else if ((int) info->nmax - 1 < len)
-        len = info->nmax - 1;
+        len = static_cast<int>(info->nmax - 1);
 
     /* haleyjd 07/19/03: bug fix: Do NOT use len as the counter
      * variable for this loop. This messes up the length calculations
@@ -767,7 +767,7 @@ int pvsnfmt_int(pvsnfmt_vars *info, pvsnfmt_intparm_t *ip)
         if (info->nmax <= 1)
             widthpad = 0;
         else if ((int) info->nmax - 1 < widthpad)
-            widthpad = info->nmax - 1;
+            widthpad = static_cast<int>(info->nmax - 1);
 
         if(widthpad)
            memset(info->pinsertion, ' ', widthpad);
@@ -862,7 +862,7 @@ int pvsnfmt_double(pvsnfmt_vars *info, double d)
 
     if (special)
     {
-        totallen = len = strlen(special);
+        totallen = len = static_cast<int>(strlen(special));
 
         /* Sign (this is silly for NaN but conforming to printf */
         if (flags & (FLAG_SIGNED | FLAG_SIGN_PAD) || sign)
@@ -906,7 +906,7 @@ int pvsnfmt_double(pvsnfmt_vars *info, double d)
             if (info->nmax <= 1)
                 pad  = 0;
             else if ((int) info->nmax - 1 < pad )
-                pad  = info->nmax - 1;
+                pad  = static_cast<int>(info->nmax - 1);
 
             if(pad)
             {
@@ -933,7 +933,7 @@ int pvsnfmt_double(pvsnfmt_vars *info, double d)
         if (info->nmax <= 0)
             len = 0;
         else if ((int) info->nmax - 1 < len)
-            len = info->nmax - 1;
+            len = static_cast<int>(info->nmax - 1);
         if(len)
            memcpy(info->pinsertion, special, len);
         info->pinsertion += len;
@@ -945,7 +945,7 @@ int pvsnfmt_double(pvsnfmt_vars *info, double d)
             if (info->nmax <= 1)
                 pad  = 0;
             else if ((int) info->nmax - 1 < pad )
-                pad  = info->nmax - 1;
+                pad  = static_cast<int>(info->nmax - 1);
 
             if(pad)
                memset(info->pinsertion, ' ', pad );
@@ -962,7 +962,7 @@ int pvsnfmt_double(pvsnfmt_vars *info, double d)
             precision = 6;
 
         digits = FCVT(value, precision, &dec, &sign);
-        len = strlen(digits);
+        len = static_cast<int>(strlen(digits));
 
         if (dec > 0)
             totallen = dec;
@@ -1030,7 +1030,7 @@ int pvsnfmt_double(pvsnfmt_vars *info, double d)
             if (info->nmax <= 1)
                 pad = 0;
             else if ((int) info->nmax - 1 < pad)
-                pad = info->nmax - 1;
+                pad = static_cast<int>(info->nmax - 1);
 
             if(pad)
             {
@@ -1090,7 +1090,7 @@ int pvsnfmt_double(pvsnfmt_vars *info, double d)
             if (info->nmax <= 1)
                 leadingzeros = 0;
             else if ((int) info->nmax /* - 1 */ < leadingzeros /* -1 */)
-                leadingzeros = info->nmax; /* -1 */
+                leadingzeros = static_cast<int>(info->nmax); /* -1 */
 
             leadingzeros--;
             if(leadingzeros > 0)
@@ -1105,7 +1105,7 @@ int pvsnfmt_double(pvsnfmt_vars *info, double d)
             if (info->nmax <= 1)
                 printdigits = 0;
             else if ((int) info->nmax - 1 < dec)
-                printdigits = info->nmax - 1;
+                printdigits = static_cast<int>(info->nmax - 1);
             else
                 printdigits = dec;
 
@@ -1145,7 +1145,7 @@ int pvsnfmt_double(pvsnfmt_vars *info, double d)
         if (info->nmax <= 1)
             printdigits = 0;
         else if ((int) info->nmax - 1 < len)
-            printdigits = info->nmax - 1;
+            printdigits = static_cast<int>(info->nmax - 1);
         else
             printdigits = len;
 
@@ -1160,7 +1160,7 @@ int pvsnfmt_double(pvsnfmt_vars *info, double d)
             if (info->nmax <= 1)
                 pad = 0;
             else if ((int) info->nmax - 1 < pad)
-                pad = info->nmax - 1;
+                pad = static_cast<int>(info->nmax - 1);
 
             if(pad)
                memset(info->pinsertion, ' ', pad);

--- a/source/r_bsp.cpp
+++ b/source/r_bsp.cpp
@@ -170,9 +170,9 @@ static void R_AddSolidSeg(int x1, int x2)
       {
          I_Error("R_AddSolidSeg: created a seg that overlaps next seg:\n"
                  "   (%i)->last = %i, (%i)->first = %i\n", 
-                 rover - solidsegs, 
-                 rover->last, 
-                 (rover + 1) - solidsegs, 
+                 static_cast<int>(rover - solidsegs),
+                 rover->last,
+                 static_cast<int>((rover + 1) - solidsegs),
                  (rover + 1)->last);
       }
    }
@@ -280,9 +280,9 @@ crunch:
       {
          I_Error("R_ClipSolidWallSegment: created a seg that overlaps next seg:\n"
                  "   (%i)->last = %i, (%i)->first = %i\n", 
-                 start - solidsegs, 
+                 static_cast<int>(start - solidsegs),
                  start->last, 
-                 (start + 1) - solidsegs, 
+                 static_cast<int>((start + 1) - solidsegs),
                  (start + 1)->last);
       }
    }

--- a/source/r_segs.cpp
+++ b/source/r_segs.cpp
@@ -239,7 +239,7 @@ static void R_RenderSegLoop(void)
    {
       I_Error("R_RenderSegLoop: invalid seg x values!\n"
               "   x1 = %d, x2 = %d, linenum = %d\n", 
-              segclip.x1, segclip.x2, segclip.line->linedef - lines);
+              segclip.x1, segclip.x2, static_cast<int>(segclip.line->linedef - lines));
    }
 #endif
 

--- a/source/r_textur.cpp
+++ b/source/r_textur.cpp
@@ -941,7 +941,7 @@ static void FinishTexture(texture_t *tex)
             col = NextTempCol(col);
             
             col->yoff = y;
-            col->ptroff = maskp - tempmask.buffer;
+            col->ptroff = static_cast<uint32_t>(maskp - tempmask.buffer);
             
             while(y < tex->height && *maskp > 0)
             {

--- a/source/r_things.cpp
+++ b/source/r_things.cpp
@@ -582,8 +582,8 @@ void R_PushPost(bool pushmasked, planehash_t *overlay)
       else
          post->masked->firstds = post->masked->firstsprite = 0;
          
-      post->masked->lastds     = ds_p - drawsegs;
-      post->masked->lastsprite = num_vissprite;
+      post->masked->lastds     = static_cast<int>(ds_p - drawsegs);
+      post->masked->lastsprite = static_cast<int>(num_vissprite);
       
       memcpy(post->masked->ceilingclip, portaltop,    sizeof(*portaltop)    * video.width);
       memcpy(post->masked->floorclip,   portalbottom, sizeof(*portalbottom) * video.width);
@@ -992,7 +992,7 @@ static void R_ProjectSprite(Mobj *thing)
 
    vis->ytop = y1;
    vis->ybottom = y2;
-   vis->sector = sec - sectors; // haleyjd: use interpolated sector
+   vis->sector = static_cast<int>(sec - sectors); // haleyjd: use interpolated sector
 
    //if(x1 < vis->x1)
       vis->startx += vis->xstep * (vis->x1 - x1);
@@ -1191,7 +1191,7 @@ static void R_DrawPSprite(pspdef_t *psp)
    vis->scale        = view.pspriteyscale;
    vis->ytop         = (view.height * 0.5f) - (M_FixedToFloat(vis->texturemid) * vis->scale);
    vis->ybottom      = vis->ytop + (spriteheight[lump] * vis->scale);
-   vis->sector       = view.sector - sectors;
+   vis->sector       = static_cast<int>(view.sector - sectors);
    
    // haleyjd 07/01/07: use actual pixel range to scale graphic
    if(flip)
@@ -1805,7 +1805,7 @@ particle_t *newParticle()
       result = Particles + inactiveParticles;
       inactiveParticles = result->next;
       result->next = activeParticles;
-      activeParticles = result - Particles;
+      activeParticles = static_cast<int>(result - Particles);
    }
 
    return result;
@@ -1960,7 +1960,7 @@ static void R_ProjectParticle(particle_t *particle)
    vis->ytop = y1;
    vis->ybottom = y2;
    vis->scale = yscale;
-   vis->sector = sector - sectors;  
+   vis->sector = static_cast<int>(sector - sectors);
    
    if(fixedcolormap ==
       fullcolormap + INVERSECOLORMAP*256*sizeof(lighttable_t))

--- a/source/s_sndseq.cpp
+++ b/source/s_sndseq.cpp
@@ -294,7 +294,7 @@ void S_StartSectorSequence(sector_t *s, int seqtype)
       origintype = SEQ_ORIGIN_SECTOR_F;
    
    S_StartSequenceNum(SECTOR_ORIGIN(s, origintype), s->sndSeqID, seqtype, 
-                      origintype, s - sectors);
+                      origintype, static_cast<int>(s - sectors));
 }
 
 //
@@ -315,7 +315,7 @@ void S_ReplaceSectorSequence(sector_t *s, int seqtype)
    S_SquashSectorSequence(s, originType);
    
    S_StartSequenceNum(SECTOR_ORIGIN(s, originType), s->sndSeqID, seqtype,
-                      originType, s - sectors);
+                      originType, static_cast<int>(s - sectors));
 }
 
 //
@@ -380,7 +380,7 @@ void S_StartSequenceName(PointThinker *mo, const char *seqname, int seqOriginTyp
 void S_StartSectorSequenceName(sector_t *s, const char *seqname, int originType)
 {
    S_StartSequenceName(SECTOR_ORIGIN(s, originType), seqname, originType, 
-                       s - sectors);
+                       static_cast<int>(s - sectors));
 }
 
 //
@@ -394,7 +394,7 @@ void S_ReplaceSectorSequenceName(sector_t *s, const char *seqname, int originTyp
    S_SquashSectorSequence(s, originType);
 
    S_StartSequenceName(SECTOR_ORIGIN(s, originType), seqname, originType,
-                       s - sectors);
+                       static_cast<int>(s - sectors));
 }
 
 //

--- a/source/sdl/macosx/SDLMain.m
+++ b/source/sdl/macosx/SDLMain.m
@@ -400,13 +400,13 @@ static void CustomApplicationMain (int argc, char **argv)
 - (NSString *)stringByReplacingRange:(NSRange)aRange with:(NSString *)aString
 {
     unsigned int bufferSize;
-    unsigned int selfLen = [self length];
-    unsigned int aStringLen = [aString length];
+    unsigned int selfLen = (unsigned)[self length];
+    unsigned int aStringLen = (unsigned)[aString length];
     unichar *buffer;
     NSRange localRange;
     NSString *result;
 
-    bufferSize = selfLen + aStringLen - aRange.length;
+    bufferSize = (unsigned)(selfLen + aStringLen - aRange.length);
     buffer = (unichar *)NSAllocateMemoryPages(bufferSize*sizeof(unichar));
     
     // Get first part into buffer

--- a/source/sdl/mmus2mid.cpp
+++ b/source/sdl/mmus2mid.cpp
@@ -678,7 +678,7 @@ int MidiToMIDI(UBYTE *mid,MIDI *mididata)
          mid += ReadLength(&mid);
       }
       mid += 4;
-      mididata->track[i].len = ReadLength(&mid);  // get length, move mid past it
+      mididata->track[i].len = static_cast<int>(ReadLength(&mid));  // get length, move mid past it
       
       // read a track
       mididata->track[i].data = 
@@ -805,7 +805,7 @@ int MIDIToMidi(MIDI *mididata, UBYTE **mid, int *midlen)
 
    // return length information
    
-   *midlen = midiptr - *mid;
+   *midlen = static_cast<int>(midiptr - *mid);
    
    return 0;
 }

--- a/source/textscreen/txt_button.c
+++ b/source/textscreen/txt_button.c
@@ -32,7 +32,7 @@ static void TXT_ButtonSizeCalc(TXT_UNCAST_ARG(button))
 {
     TXT_CAST_ARG(txt_button_t, button);
 
-    button->widget.w = strlen(button->label);
+    button->widget.w = (unsigned)strlen(button->label);
     button->widget.h = 1;
 }
 
@@ -54,7 +54,7 @@ static void TXT_ButtonDrawer(TXT_UNCAST_ARG(button), int selected)
 
     TXT_DrawString(button->label);
     
-    for (i=strlen(button->label); i < w; ++i)
+    for (i=(int)strlen(button->label); i < w; ++i)
     {
         TXT_DrawString(" ");
     }

--- a/source/textscreen/txt_checkbox.c
+++ b/source/textscreen/txt_checkbox.c
@@ -34,7 +34,7 @@ static void TXT_CheckBoxSizeCalc(TXT_UNCAST_ARG(checkbox))
 
     // Minimum width is the string length + two spaces for padding
 
-    checkbox->widget.w = strlen(checkbox->label) + 6;
+    checkbox->widget.w = (unsigned)(strlen(checkbox->label) + 6);
     checkbox->widget.h = 1;
 }
 
@@ -74,7 +74,7 @@ static void TXT_CheckBoxDrawer(TXT_UNCAST_ARG(checkbox), int selected)
 
     TXT_DrawString(checkbox->label);
     
-    for (i=strlen(checkbox->label); i < w-6; ++i)
+    for (i=(int)strlen(checkbox->label); i < w-6; ++i)
     {
         TXT_DrawString(" ");
     }

--- a/source/textscreen/txt_dropdown.c
+++ b/source/textscreen/txt_dropdown.c
@@ -169,7 +169,7 @@ static int DropdownListWidth(txt_dropdown_list_t *list)
 
     for (i=0; i<list->num_values; ++i)
     {
-        int w = strlen(list->values[i]);
+        int w = (int)strlen(list->values[i]);
         if (w > result) 
         {
             result = w;
@@ -222,7 +222,7 @@ static void TXT_DropdownListDrawer(TXT_UNCAST_ARG(list), int selected)
 
     TXT_DrawString(str);
 
-    for (i=strlen(str); i<list->widget.w; ++i) 
+    for (i=(unsigned)strlen(str); i<list->widget.w; ++i)
     {
         TXT_DrawString(" ");
     }

--- a/source/textscreen/txt_gui.c
+++ b/source/textscreen/txt_gui.c
@@ -170,7 +170,7 @@ void TXT_DrawWindowFrame(char *title, int x, int y, int w, int h)
             TXT_DrawString(" ");
         }
     
-        TXT_GotoXY(x + (w - strlen(title)) / 2, y + 1);
+        TXT_GotoXY((int)(x + (w - strlen(title)) / 2), y + 1);
         TXT_DrawString(title);
     }
 
@@ -246,7 +246,7 @@ void TXT_DrawString(char *s)
         }
     }
 
-    TXT_GotoXY(x + strlen(s), y);
+    TXT_GotoXY((int)(x + strlen(s)), y);
 }
 
 void TXT_DrawHorizScrollbar(int x, int y, int w, int cursor, int range)

--- a/source/textscreen/txt_inputbox.c
+++ b/source/textscreen/txt_inputbox.c
@@ -80,7 +80,7 @@ static void TXT_InputBoxDrawer(TXT_UNCAST_ARG(inputbox), int selected)
     
     TXT_DrawString(inputbox->buffer);
 
-    chars = strlen(inputbox->buffer);
+    chars = (int)strlen(inputbox->buffer);
 
     if (chars < w && inputbox->editing && selected)
     {

--- a/source/textscreen/txt_label.c
+++ b/source/textscreen/txt_label.c
@@ -60,10 +60,10 @@ static void TXT_LabelDrawer(TXT_UNCAST_ARG(label), int selected)
                 align_indent = 0;
                 break;
             case TXT_HORIZ_CENTER:
-                align_indent = (label->w - strlen(label->lines[y])) / 2;
+                align_indent = (unsigned)((label->w - strlen(label->lines[y])) / 2);
                 break;
             case TXT_HORIZ_RIGHT:
-                align_indent = label->w - strlen(label->lines[y]);
+                align_indent = (unsigned)(label->w - strlen(label->lines[y]));
                 break;
         }
         
@@ -157,7 +157,7 @@ void TXT_SetLabel(txt_label_t *label, char *value)
     for (y=0; y<label->h; ++y)
     {
         if (strlen(label->lines[y]) > label->w)
-            label->w = strlen(label->lines[y]);
+            label->w = (unsigned)strlen(label->lines[y]);
     }
 }
 

--- a/source/textscreen/txt_radiobutton.c
+++ b/source/textscreen/txt_radiobutton.c
@@ -34,7 +34,7 @@ static void TXT_RadioButtonSizeCalc(TXT_UNCAST_ARG(radiobutton))
 
     // Minimum width is the string length + two spaces for padding
 
-    radiobutton->widget.w = strlen(radiobutton->label) + 6;
+    radiobutton->widget.w = (unsigned)(strlen(radiobutton->label) + 6);
     radiobutton->widget.h = 1;
 }
 
@@ -74,7 +74,7 @@ static void TXT_RadioButtonDrawer(TXT_UNCAST_ARG(radiobutton), int selected)
 
     TXT_DrawString(radiobutton->label);
     
-    for (i=strlen(radiobutton->label); i < w-6; ++i)
+    for (i=(int)strlen(radiobutton->label); i < w-6; ++i)
     {
         TXT_DrawString(" ");
     }

--- a/source/textscreen/txt_separator.c
+++ b/source/textscreen/txt_separator.c
@@ -34,7 +34,7 @@ static void TXT_SeparatorSizeCalc(TXT_UNCAST_ARG(separator))
     {
         // Minimum width is the string length + two spaces for padding
 
-        separator->widget.w = strlen(separator->label) + 2;
+        separator->widget.w = (unsigned)(strlen(separator->label) + 2);
     }
     else
     {

--- a/source/textscreen/txt_spinctrl.c
+++ b/source/textscreen/txt_spinctrl.c
@@ -57,7 +57,7 @@ static unsigned int IntWidth(int val)
 
     sprintf(buf, "%i", val);
 
-    return strlen(buf);
+    return (unsigned)strlen(buf);
 }
 
 static unsigned int FloatWidth(float val, float step)
@@ -175,7 +175,7 @@ static void TXT_SpinControlDrawer(TXT_UNCAST_ARG(spincontrol), int selected)
     
     i = 0;
 
-    padding = spincontrol->widget.w - strlen(spincontrol->buffer) - 4;
+    padding = (unsigned)(spincontrol->widget.w - strlen(spincontrol->buffer) - 4);
 
     while (i < padding)
     {

--- a/source/textscreen/txt_window_action.c
+++ b/source/textscreen/txt_window_action.c
@@ -37,7 +37,7 @@ static void TXT_WindowActionSizeCalc(TXT_UNCAST_ARG(action))
 
     // Minimum width is the string length + two spaces for padding
 
-    action->widget.w = strlen(action->label) + strlen(buf) + 1;
+    action->widget.w = (unsigned)(strlen(action->label) + strlen(buf) + 1);
     action->widget.h = 1;
 }
 

--- a/source/v_image.cpp
+++ b/source/v_image.cpp
@@ -368,7 +368,7 @@ void VImageManager::determineLinearDimensions(void *data, size_t size,
          if(!(size % 320)) // covers fullscreen gfx and Heretic AUTOPAGE
          {
             w = 320;
-            h = size / 320;
+            h = static_cast<int>(size / 320);
          }
          else
             V_linearOptimalSize(size, w, h);

--- a/source/v_patch.cpp
+++ b/source/v_patch.cpp
@@ -825,7 +825,7 @@ patch_t *V_LinearToPatch(byte *linear, int w, int h, size_t *memsize,
    for(x = 0; x < w; ++x)
    {
       // set entry in columnofs table
-      columnofs[x] = dest - out;
+      columnofs[x] = static_cast<int>(dest - out);
 
       // set basic column properties
       c = (column_t *)dest;

--- a/source/w_wad.cpp
+++ b/source/w_wad.cpp
@@ -1406,7 +1406,7 @@ int WadDirectory::lumpLength(int lump)
 {
    if(lump < 0 || lump >= numlumps)
       I_Error("WadDirectory::LumpLength: %i >= numlumps\n", lump);
-   return lumpinfo[lump]->size;
+   return static_cast<int>(lumpinfo[lump]->size);
 }
 
 int W_LumpLength(int lump)
@@ -1482,7 +1482,7 @@ int WadDirectory::readLumpHeader(int lump, void *dest, size_t size)
 
    memcpy(dest, data, size);
    
-   return size;
+   return static_cast<int>(size);
 }
 
 int W_ReadLumpHeader(int lump, void *dest, size_t size)

--- a/source/w_zip.cpp
+++ b/source/w_zip.cpp
@@ -621,7 +621,7 @@ protected:
          atEOF = true;
 
       zlStream.next_in  = deflateBuffer;
-      zlStream.avail_in = bytesRead;
+      zlStream.avail_in = static_cast<uInt>(bytesRead);
    }
 
 public:
@@ -676,7 +676,7 @@ static void ZIP_ReadDeflated(InBuffer &fin, void *buffer, size_t len)
 {
    ZIPDeflateReader reader(fin);
 
-   reader.read(buffer, len);
+   reader.read(buffer, static_cast<uint32_t>(len));
 }
 
 //

--- a/zlib/crc32.c
+++ b/zlib/crc32.c
@@ -256,8 +256,8 @@ unsigned long ZEXPORT crc32(crc, buf, len)
 
 /* ========================================================================= */
 #define DOLIT4 c ^= *buf4++; \
-        c = crc_table[3][c & 0xff] ^ crc_table[2][(c >> 8) & 0xff] ^ \
-            crc_table[1][(c >> 16) & 0xff] ^ crc_table[0][c >> 24]
+        c = (u4)(crc_table[3][c & 0xff] ^ crc_table[2][(c >> 8) & 0xff] ^ \
+            crc_table[1][(c >> 16) & 0xff] ^ crc_table[0][c >> 24])
 #define DOLIT32 DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4
 
 /* ========================================================================= */
@@ -272,7 +272,7 @@ local unsigned long crc32_little(crc, buf, len)
     c = (u4)crc;
     c = ~c;
     while (len && ((ptrdiff_t)buf & 3)) {
-        c = crc_table[0][(c ^ *buf++) & 0xff] ^ (c >> 8);
+        c = (u4)(crc_table[0][(c ^ *buf++) & 0xff] ^ (c >> 8));
         len--;
     }
 
@@ -288,7 +288,7 @@ local unsigned long crc32_little(crc, buf, len)
     buf = (const unsigned char FAR *)buf4;
 
     if (len) do {
-        c = crc_table[0][(c ^ *buf++) & 0xff] ^ (c >> 8);
+        c = (u4)(crc_table[0][(c ^ *buf++) & 0xff] ^ (c >> 8));
     } while (--len);
     c = ~c;
     return (unsigned long)c;
@@ -296,8 +296,8 @@ local unsigned long crc32_little(crc, buf, len)
 
 /* ========================================================================= */
 #define DOBIG4 c ^= *++buf4; \
-        c = crc_table[4][c & 0xff] ^ crc_table[5][(c >> 8) & 0xff] ^ \
-            crc_table[6][(c >> 16) & 0xff] ^ crc_table[7][c >> 24]
+        c = (u4)(crc_table[4][c & 0xff] ^ crc_table[5][(c >> 8) & 0xff] ^ \
+            crc_table[6][(c >> 16) & 0xff] ^ crc_table[7][c >> 24])
 #define DOBIG32 DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4
 
 /* ========================================================================= */
@@ -312,7 +312,7 @@ local unsigned long crc32_big(crc, buf, len)
     c = REV((u4)crc);
     c = ~c;
     while (len && ((ptrdiff_t)buf & 3)) {
-        c = crc_table[4][(c >> 24) ^ *buf++] ^ (c << 8);
+        c = (u4)(crc_table[4][(c >> 24) ^ *buf++] ^ (c << 8));
         len--;
     }
 
@@ -330,7 +330,7 @@ local unsigned long crc32_big(crc, buf, len)
     buf = (const unsigned char FAR *)buf4;
 
     if (len) do {
-        c = crc_table[4][(c >> 24) ^ *buf++] ^ (c << 8);
+        c = (u4)(crc_table[4][(c >> 24) ^ *buf++] ^ (c << 8));
     } while (--len);
     c = ~c;
     return (unsigned long)(REV(c));


### PR DESCRIPTION
Here are Eternity 64-bit warnings I decided to patch, mostly by using static_cast on the right side of assignment operators (=) or function arguments. See the full text in the latest commit comment.