### PR TITLE
ZDoom node detection fix

### DIFF
--- a/source/p_setup.cpp
+++ b/source/p_setup.cpp
@@ -753,19 +753,19 @@ static bool P_CheckForZDoomUncompressedNodes(int lumpnum)
       bdata += 4;
 
       uint32_t num = GetBinaryUDWord(&bdata);
-      if(num > ::numvertexes)  // original vertices
+      if(num > ::numvertexes)                      // original vertices
          return false;
 
-      num = GetBinaryUDWord(&bdata);       // internal vertices
-      if((bdata += 8 * num) >= end)                // advance
+      num = GetBinaryUDWord(&bdata);               // internal vertices
+      if((bdata += 8 * num) + 4 > end)             // advance
          return false;
 
       num = GetBinaryUDWord(&bdata);               // subsectors
-      if((bdata += 4 * num) >= end)
+      if((bdata += 4 * num) + 4 > end)
          return false;
 
       num = GetBinaryUDWord(&bdata);               // segs
-      if((bdata += 11 * num) >= end)
+      if((bdata += 11 * num) + 4 > end)
          return false;
 
       num = GetBinaryUDWord(&bdata);               // nodes


### PR DESCRIPTION
NODES lumps with "XNOD" in the 4 bytes will be checked against size and other data (such as ::numvertexes) to reduce the risk of mis-detecting Doom NODES as ZDoom extended nodes.

This is a bugfix to issue #22 https://github.com/team-eternity/eternity/issues/22