### PR TITLE
Removed Charles Gunyon from credits, added Ioan Chera.

### DIFF
--- a/source/mn_misc.cpp
+++ b/source/mn_misc.cpp
@@ -390,7 +390,7 @@ static const char *cat_strs[NUMCATS] =
 
 static const char *val_strs[NUMCATS] =
 {
-   "James Haley\nStephen McGranahan\nCharles Gunyon\nDavid Hill\n",
+   "James Haley\nStephen McGranahan\nDavid Hill\nIoan Chera\n",
    
    FC_HI "SMMU" FC_NORMAL " by Simon Howard\n",
 


### PR DESCRIPTION
Given Charles' inactivity and Ioan's official addition to Team Eternity, it seemed prudent to do so. Both would have been there, if it weren't for issues involved with Heretic and the lower margin (or lack thereof).