### PR TITLE
Made it so that open scripts are delayed until after wiping.

### DIFF
--- a/source/acs_intr.cpp
+++ b/source/acs_intr.cpp
@@ -303,6 +303,10 @@ static void ACS_runOpenScript(ACSVM *vm, ACSScript *acs, Mobj *trigger)
    // open scripts wait one second before running
    if(!trigger && LevelInfo.acsOpenDelay)
       newScript->delay = TICRATE;
+   else
+      // wait a tic, otherwise the script runs during screen wipe
+      // FIXME: Doesn't work if wipes happening while wiping (like idclevving before a wipe finishes)
+      newScript->delay = 1;
 
    newScript->trigger = trigger;
 


### PR DESCRIPTION
Bear in mind that this doesn't quite work if you wipe while wiping. In the example video, the howl is supposed to occur after the wipe.
https://www.youtube.com/watch?v=1qSccCmwytA
