### PR TITLE
Fix R_PointToAngle2 for ARM 

### DIFF
--- a/source/r_main.cpp
+++ b/source/r_main.cpp
@@ -353,7 +353,7 @@ angle_t R_PointToAngle2(fixed_t pviewx, fixed_t pviewy, fixed_t x, fixed_t y)
    else
    {
       // Sneakernets: Fix cast issue on ARM
-      return angle_t(int(atan2(double(y), x) * (ANG180/PI)));
+      return angle_t(int(atan2(double(y), x) * (ANG180 / PI)));
    }
 
    return 0;

--- a/source/r_main.cpp
+++ b/source/r_main.cpp
@@ -352,7 +352,8 @@ angle_t R_PointToAngle2(fixed_t pviewx, fixed_t pviewy, fixed_t x, fixed_t y)
    }
    else
    {
-      return (angle_t)(atan2((double)y, x) * (ANG180 / PI));
+      // Sneakernets: Fix cast issue on ARM
+      return angle_t(int(atan2(double(y), x) * (ANG180/PI)));
    }
 
    return 0;


### PR DESCRIPTION
On ARM processors, the next to final `return` contains `atan2`, which  needs to be explicitly cast to a signed `int`, else rendering issues will occur on large maps. Tested on one of Mechadon's maps, and this change fixes the massive HOM on one quadrant of the map.