### PR TITLE
README: Remove the “Kate monster”

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,8 +35,6 @@ for editors and players alike, including:
 
 * Heretic, Hexen, and Strife support in-progress.
 
-* Includes the Kate monster.
-
 For more on its features, check out the
 http://eternity.youfailit.net/index.php?title=Main_Page[Eternity
 Engine Wiki].


### PR DESCRIPTION
This was a bit of an in-joke about Kate Fox, a former Eternity
developer that has passed away.  Doesn’t seem appropriate here anymore.