### PR TITLE
sort+binary search for drawsegs obscuring sprites

### DIFF
--- a/source/r_things.cpp
+++ b/source/r_things.cpp
@@ -1518,14 +1518,42 @@ static void R_DrawSpriteInDSRange(vissprite_t *spr, int firstds, int lastds)
    // e6y: optimization
    if(drawsegs_xrange_count)
    {
+      
+
       drawsegs_xrange_t *dsx = drawsegs_xrange;
 
-      // drawsegs_xrange is sorted by ::x1
+      {
+         // ano (apr 2018) - we will binary search the
+         // presorted drawsegs_xrange
+         // in order to (hopefully) greatly reduce the
+         // # of segs we have to check
+         int lower = 0;
+         int upper = drawsegs_xrange_count;
+
+         while (upper - lower > 1)
+         {
+            int midpoint = (upper + lower) / 2;
+
+            if (drawsegs_xrange[midpoint].x2 < spr->x1)
+            {
+               lower = midpoint;
+            }
+            else
+            {
+               upper = midpoint;
+            }
+         } // while
+         dsx += lower;
+      } // end binary search
+
       // haleyjd: way faster to use a pointer here
       while((ds = dsx->user))
       {
          // determine if the drawseg obscures the sprite
-         if(dsx->x1 > spr->x2 || dsx->x2 < spr->x1)
+         // ano (apr 2018) -- previously this included a check for
+         // || dsx->x2 < spr->x1
+         // however due to the binary search we no longer need it
+         if(dsx->x1 > spr->x2)
          {
             ++dsx;
             continue;      // does not cover sprite
@@ -1566,7 +1594,7 @@ static void R_DrawSpriteInDSRange(vissprite_t *spr, int firstds, int lastds)
          {
             for(x = r1; x <= r2; x++)
             {
-               if(clipbot[x] == CLIP_UNDEF)
+               if (clipbot[x] == CLIP_UNDEF || clipbot[x] > ds->sprbottomclip[x])
                   clipbot[x] = ds->sprbottomclip[x];
             }
          }
@@ -1576,7 +1604,7 @@ static void R_DrawSpriteInDSRange(vissprite_t *spr, int firstds, int lastds)
          {
             for(x = r1; x <= r2; x++)
             {
-               if(cliptop[x] == CLIP_UNDEF)
+               if(cliptop[x] == CLIP_UNDEF || cliptop[x] < ds->sprtopclip[x])
                   cliptop[x] = ds->sprtopclip[x];
             }
          }
@@ -1752,6 +1780,19 @@ static void R_DrawSpriteInDSRange(vissprite_t *spr, int firstds, int lastds)
 }
 
 //
+// R_DrawsegsXRangeCompare
+//
+// qsort callback to compare drawsegs_xrange_t by x2
+//
+static int R_DrawsegsXRangeCompare(const void *arga, const void *argb)
+{
+   drawsegs_xrange_t *arg1 = (drawsegs_xrange_t*)arga;
+   drawsegs_xrange_t *arg2 = (drawsegs_xrange_t*)argb;
+
+   return arg1->x2 - arg2->x2;
+}
+
+//
 // R_DrawPostBSP
 //
 // Draws the items in the Post-BSP stack.
@@ -1803,12 +1844,18 @@ void R_DrawPostBSP()
                      drawsegs_xrange_count++;
                   }
                }
+               
+               // ano (apr-2018) -- sort our drawsegs by x2 in order to later
+               // do a binary search on the list for speed
+               qsort(drawsegs_xrange, drawsegs_xrange_count, sizeof(drawsegs_xrange_t), R_DrawsegsXRangeCompare);
+
                // haleyjd: terminate with a NULL user for faster loop - adds ~3 FPS
                drawsegs_xrange[drawsegs_xrange_count].user = NULL;
             }
 
             ptop    = masked->ceilingclip;
             pbottom = masked->floorclip;
+
 
             for(int i = lastsprite - firstsprite; --i >= 0; )
                R_DrawSpriteInDSRange(vissprite_ptrs[i], firstds, lastds);         // killough


### PR DESCRIPTION
optimization for bad-case of many drawsegs in R_DrawSpriteInDSRange &
R_DrawPostBSP. we sort the drawsegs, then use a binarysearch to set the
starting point in drawsegs_xrange to check per sprite. this saves a lot
of checks vs the original linear pass through the array, assuming there
are many drawsegs. in tests on maps like The Given, i had a 5-10fps
increase (up to 25-30 total). there is a drawback: additional overhead
from the sort and the binary search as well as some additional checks
later in the code (to compensate for messing up the previous order),
means that we lose some speed in very simple scenes. In testing, this
amounts to  losing 1-2 fps on scenes that are already 200+fps