### PR TITLE
Add support for long file names in sound definitions

### DIFF
--- a/source/e_edf.cpp
+++ b/source/e_edf.cpp
@@ -153,10 +153,10 @@ int blankSpriteNum;
 
 // function prototypes for libConfuse callbacks (aka EDF functions)
 
-static int bex_include(cfg_t *cfg, cfg_opt_t *opt, int argc, 
+static int bex_include(cfg_t *cfg, cfg_opt_t *opt, int argc,
                        const char **argv);
 
-static int bex_override(cfg_t *cfg, cfg_opt_t *opt, int argc, 
+static int bex_override(cfg_t *cfg, cfg_opt_t *opt, int argc,
                         const char **argv);
 
 static int edf_ifenabled(cfg_t *cfg, cfg_opt_t *opt, int argc,
@@ -353,7 +353,7 @@ static void E_EDFCloseVerboseLog()
 {
    if(edf_output)
    {
-      E_EDFLogPuts("Closing log file\n");      
+      E_EDFLogPuts("Closing log file\n");
       fclose(edf_output);
    }
 
@@ -381,7 +381,7 @@ void E_EDFLogPrintf(const char *msg, ...)
    if(edf_output)
    {
       va_list v;
-      
+
       va_start(v, msg);
       vfprintf(edf_output, msg, v);
       va_end(v);
@@ -406,7 +406,7 @@ void E_EDFLoggedErr(int lv, const char *msg, ...)
 
       while(lv--)
          putc('\t', edf_output);
-      
+
       va_start(va2, msg);
       vfprintf(edf_output, msg, va2);
       va_end(va2);
@@ -427,7 +427,7 @@ static bool edf_warning_out;
 // E_EDFLoggedWarning
 //
 // Similar to above, but this is just a warning message. The number of warnings
-// that occur will be printed to the system console after EDF processing is 
+// that occur will be printed to the system console after EDF processing is
 // finished, so that users are aware that warnings have occured even if verbose
 // logging is not enabled.
 //
@@ -445,7 +445,7 @@ void E_EDFLoggedWarning(int lv, const char *msg, ...)
       vfprintf(edf_output, msg, va);
       va_end(va);
    }
-   
+
    // allow display of warning messages on the system console too
    if(edf_warning_out)
    {
@@ -524,7 +524,7 @@ static void edf_error(cfg_t *cfg, const char *fmt, va_list ap)
 // integrate BEX features such as string editing into the
 // EDF/BEX superlanguage.
 //
-// This function interprets paths relative to the current 
+// This function interprets paths relative to the current
 // file.
 //
 static int bex_include(cfg_t *cfg, cfg_opt_t *opt, int argc,
@@ -564,7 +564,7 @@ static int bex_include(cfg_t *cfg, cfg_opt_t *opt, int argc,
    return 0;
 }
 
-// 
+//
 // bex_override
 //
 // haleyjd 09/26/10: Setting this flag in an EDF will disable loading of
@@ -596,19 +596,19 @@ static E_Enable_t edf_enables[] =
    // all game modes are enabled by default
    { "DOOM",     1 },
    { "HERETIC",  1 },
-   
+
    // terminator
    { NULL }
 };
 
-// 
+//
 // E_EDFSetEnableValue
 //
-// This function lets the rest of the engine be able to set EDF enable values 
-// before parsing begins. This is used to turn DOOM and HERETIC modes on and 
-// off when loading the default root.edf. This saves time and memory. Note 
-// that they are enabled when user EDFs are loaded, but users can use the 
-// disable function to turn them off explicitly in that case when the 
+// This function lets the rest of the engine be able to set EDF enable values
+// before parsing begins. This is used to turn DOOM and HERETIC modes on and
+// off when loading the default root.edf. This saves time and memory. Note
+// that they are enabled when user EDFs are loaded, but users can use the
+// disable function to turn them off explicitly in that case when the
 // definitions are not needed.
 //
 void E_EDFSetEnableValue(const char *name, int value)
@@ -627,8 +627,8 @@ static void E_EchoEnables()
 
    while(enable->name)
    {
-      E_EDFLogPrintf("\t\t%s is %s\n", 
-                     enable->name, 
+      E_EDFLogPrintf("\t\t%s is %s\n",
+                     enable->name,
                      enable->enabled ? "enabled" : "disabled");
       ++enable;
    }
@@ -637,8 +637,8 @@ static void E_EchoEnables()
 //
 // edf_ifenabled
 //
-// haleyjd 01/14/04: Causes the parser to skip forward, looking 
-// for the next endif function and then calling it, if the 
+// haleyjd 01/14/04: Causes the parser to skip forward, looking
+// for the next endif function and then calling it, if the
 // parameter isn't defined. I hacked the support for this
 // into libConfuse without too much ugliness.
 //
@@ -753,7 +753,7 @@ static int edf_ifdisabled(cfg_t *cfg, cfg_opt_t *opt, int argc,
          return 1;
       }
 
-      // use AND logic: the block will be evalued if ALL 
+      // use AND logic: the block will be evalued if ALL
       // options are disabled.
       if(!(disabled = disabled && !edf_enables[idx].enabled))
          break;
@@ -914,7 +914,7 @@ static int edf_includeifenabled(cfg_t *cfg, cfg_opt_t *opt, int argc,
 // Game Type Functions
 //
 // haleyjd 09/06/05:
-// These are for things which must vary strictly on game type and not 
+// These are for things which must vary strictly on game type and not
 // simply whether or not a given game's definitions are enabled.
 //
 
@@ -1009,7 +1009,7 @@ static int edf_ifngametype(cfg_t *cfg, cfg_opt_t *opt, int argc,
 //
 // E_CreateCfg
 //
-// haleyjd 03/21/10: Separated from E_ParseEDF[File|Lump]. Creates and 
+// haleyjd 03/21/10: Separated from E_ParseEDF[File|Lump]. Creates and
 // initializes a libConfuse cfg_t object for use by EDF. All definitions
 // are now accumulated into this singular cfg_t, as opposed to being
 // merged from separately allocated ones for secondary EDF sources such
@@ -1039,7 +1039,7 @@ static void E_ParseEDFFile(cfg_t *cfg, const char *filename)
 
    if((err = cfg_parse(cfg, filename)))
    {
-      E_EDFLoggedErr(1, 
+      E_EDFLoggedErr(1,
          "E_ParseEDFFile: failed to parse %s (code %d)\n",
          filename, err);
    }
@@ -1069,7 +1069,7 @@ static void E_ParseLumpRecursive(cfg_t *cfg, const char *name, int ln)
          // try to parse it
          if((err = cfg_parselump(cfg, name, ln)))
          {
-            E_EDFLoggedErr(1, 
+            E_EDFLoggedErr(1,
                "E_ParseEDFLump: failed to parse EDF lump %s (#%d, code %d)\n",
                name, ln, err);
          }
@@ -1102,7 +1102,7 @@ static void E_ParseEDFLump(cfg_t *cfg, const char *lumpname)
 // E_ParseEDFLumpOptional
 //
 // Calls the function above, but checks to make sure the lump exists
-// first so that an error will not occur. Returns immediately if the 
+// first so that an error will not occur. Returns immediately if the
 // lump wasn't found.
 //
 static bool E_ParseEDFLumpOptional(cfg_t *cfg, const char *lumpname)
@@ -1179,7 +1179,7 @@ static void E_ProcessSpriteVars(cfg_t *cfg)
    sprnum = E_SpriteNumForName(str);
    if(sprnum == -1)
    {
-      E_EDFLoggedErr(2, 
+      E_EDFLoggedErr(2,
          "E_ProcessSpriteVars: invalid blank sprite name: '%s'\n", str);
    }
    E_EDFLogPrintf("\t\tSet sprite %s(#%d) as blank sprite\n", str, sprnum);
@@ -1200,6 +1200,7 @@ sfxinfo_t NullSound =
    NULL, NULL, NULL, 0,          // link, alias, random sounds
    NULL, 0, 0, 0,                // data, length, alen, usefulness
    { 'n', 'o', 'n', 'e', '\0' }, // mnemomnic
+   NULL, NULL,                   // lfn, pcslfn
    { NULL, NULL, NULL, 0 },      // numlinks
    NULL,                         // next
    0                             // dehackednum
@@ -1221,7 +1222,7 @@ static void E_CollectNames(cfg_t *cfg)
 // E_ProcessStatesAndThings
 //
 // E_ProcessEDF now calls this function to accomplish all state
-// and thing processing. 
+// and thing processing.
 //
 static void E_ProcessStatesAndThings(cfg_t *cfg)
 {
@@ -1266,7 +1267,7 @@ static void E_ProcessCast(cfg_t *cfg)
    cfg_t **ci_order;
 
    E_EDFLogPuts("\t* Processing cast call\n");
-   
+
    // get number of cast sections
    numcastsections = cfg_size(cfg, SEC_CAST);
 
@@ -1309,13 +1310,13 @@ static void E_ProcessCast(cfg_t *cfg)
    {
       for(int i = 0; i < numcastorder; i++)
       {
-         const char *title = cfg_getnstr(cfg, SEC_CASTORDER, i);         
+         const char *title = cfg_getnstr(cfg, SEC_CASTORDER, i);
          cfg_t *section    = cfg_gettsec(cfg, SEC_CAST, title);
 
          if(!section)
          {
-            E_EDFLoggedErr(2, 
-               "E_ProcessCast: unknown cast member '%s' in castorder\n", 
+            E_EDFLoggedErr(2,
+               "E_ProcessCast: unknown cast member '%s' in castorder\n",
                title);
          }
 
@@ -1341,7 +1342,7 @@ static void E_ProcessCast(cfg_t *cfg)
 
       // resolve thing type
       tempstr = cfg_getstr(castsec, ITEM_CAST_TYPE);
-      if(!tempstr || 
+      if(!tempstr ||
          (tempint = E_ThingNumForName(tempstr)) == -1)
       {
          E_EDFLoggedWarning(2, "Warning: cast %d: unknown thing type %s\n",
@@ -1381,7 +1382,7 @@ static void E_ProcessCast(cfg_t *cfg)
 
          // name of sound to play
          name = cfg_getstr(soundsec, ITEM_CAST_SOUNDNAME);
-         
+
          // haleyjd 03/22/06: modified to support dehnum auto-allocation
          if((sfx = E_EDFSoundForName(name)) == NULL)
          {
@@ -1418,7 +1419,7 @@ static void E_ProcessCast(cfg_t *cfg)
 // a default probability array for the boss_spawn_probs list,
 // for backward compatibility
 
-static int BossDefaults[11] = 
+static int BossDefaults[11] =
 {
    50, 90, 120, 130, 160, 162, 172, 192, 222, 246, 256
 };
@@ -1453,7 +1454,7 @@ static void E_ProcessBossTypes(cfg_t *cfg)
 
    if(useProbs ? numTypes != numProbs : numTypes != 11)
    {
-      E_EDFLoggedErr(2, 
+      E_EDFLoggedErr(2,
          "E_ProcessBossTypes: %d boss types, %d boss probs\n",
          numTypes, useProbs ? numProbs : 11);
    }
@@ -1489,7 +1490,7 @@ static void E_ProcessBossTypes(cfg_t *cfg)
    // check that the probabilities total 256
    if(useProbs && a != 256)
    {
-      E_EDFLoggedErr(2, 
+      E_EDFLoggedErr(2,
          "E_ProcessBossTypes: boss spawn probs do not total 256\n");
    }
 
@@ -1622,10 +1623,10 @@ static void E_DoEDFProcessing(cfg_t *cfg, bool firsttime)
    if(firsttime)
       E_EchoEnables();
 
-   // NOTE: The order of most of the following calls is extremely 
-   // important and must be preserved, unless the static routines 
+   // NOTE: The order of most of the following calls is extremely
+   // important and must be preserved, unless the static routines
    // above and in other files are rewritten accordingly.
-   
+
    // process strings
    E_ProcessStrings(cfg);
 
@@ -1649,7 +1650,7 @@ static void E_DoEDFProcessing(cfg_t *cfg, bool firsttime)
 
    // process frame and thing definitions (made dynamic 11/06/11)
    E_ProcessStatesAndThings(cfg);
- 
+
    // process sprite-related variables (made dynamic 11/21/11)
    E_ProcessSpriteVars(cfg);
 
@@ -1737,14 +1738,14 @@ static void E_CleanUpEDF(cfg_t *cfg)
 //
 // E_ProcessEDF
 //
-// Public function to parse and process the root EDF file. Called by 
+// Public function to parse and process the root EDF file. Called by
 // D_DoomInit.  Assumes that certain BEX data structures, especially the
 // codepointer hash table, have already been built.
 //
 void E_ProcessEDF(const char *filename)
 {
    cfg_t *cfg;
-   
+
    //
    // Initialization - open log and create a cfg_t
    //
@@ -1780,7 +1781,7 @@ void E_ProcessEDF(const char *filename)
 void E_ProcessNewEDF()
 {
    cfg_t *cfg;
-   
+
    //
    // Initialization - open log and create a cfg_t
    //

--- a/source/e_sound.cpp
+++ b/source/e_sound.cpp
@@ -25,8 +25,8 @@
 //
 // Maintains the globally-used sound hash tables, for lookup by
 // assigned mnemonics and DeHackEd numbers. EDF-defined sounds are
-// processed and linked into the tables first. Any wad lumps with 
-// names starting with DS* are later added as the wads that contain 
+// processed and linked into the tables first. Any wad lumps with
+// names starting with DS* are later added as the wads that contain
 // them are loaded.
 //
 // Note that wad sounds can't be referred to via DeHackEd, which
@@ -368,7 +368,7 @@ bool E_AutoAllocSoundDEHNum(sfxinfo_t *sfx)
    do
    {
       dehnum = edf_alloc_sound_dehnum--;
-   } 
+   }
    while(dehnum > 0 && E_SoundForDEHNum(dehnum) != NULL);
 
    // ran out while searching for an unused number?
@@ -398,12 +398,12 @@ sfxinfo_t *E_NewWadSound(const char *name)
    strncpy(mnemonic, name+2, 9);
 
    sfx = E_EDFSoundForName(mnemonic);
-   
+
    if(!sfx)
    {
       // create a new one and hook into hashchain
       sfx = ecalloc(sfxinfo_t *, 1, sizeof(sfxinfo_t));
-      
+
       strncpy(sfx->name, name, 9);
       strncpy(sfx->mnemonic, mnemonic, 9);
 
@@ -414,17 +414,17 @@ sfxinfo_t *E_NewWadSound(const char *name)
       sfx->clipping_dist = S_CLIPPING_DIST;
       sfx->close_dist    = S_CLOSE_DIST;
       sfx->dehackednum   = -1;              // not accessible to DeHackEd
-      
+
       E_AddSoundToHash(sfx);
    }
 
    return sfx;
 }
 
-// 
+//
 // E_NewSndInfoSound
 //
-// haleyjd 03/27/11: 
+// haleyjd 03/27/11:
 // Creates a sfxinfo_t for a SNDINFO entry.
 //
 sfxinfo_t *E_NewSndInfoSound(const char *mnemonic, const char *name)
@@ -518,9 +518,9 @@ static void E_ProcessSound(sfxinfo_t *sfx, cfg_t *section, bool def)
    bool explicitLumpName = false;
    int tempint;
 
-   // preconditions: 
-   
-   // sfx->mnemonic is valid, and this sfxinfo_t has already been 
+   // preconditions:
+
+   // sfx->mnemonic is valid, and this sfxinfo_t has already been
    // added to the sound hash table earlier by E_ProcessSounds
 
    // process the lump name
@@ -534,7 +534,11 @@ static void E_ProcessSound(sfxinfo_t *sfx, cfg_t *section, bool def)
       {
          const char *lumpname = cfg_getstr(section, ITEM_SND_LUMP);
 
-         strncpy(sfx->name, lumpname, 9);
+         // alison: set the long file name if applicable
+         if(lumpname[0] == '/')
+            E_ReplaceString(sfx->lfn, estrdup(&lumpname[1]));
+         else
+            strncpy(sfx->name, lumpname, 9);
 
          // mark that the lump name has been listed explicitly
          explicitLumpName = true;
@@ -546,7 +550,7 @@ static void E_ProcessSound(sfxinfo_t *sfx, cfg_t *section, bool def)
    {
       // haleyjd 09/23/06: When definitions specify a lump name explicitly and
       // do not specify a value for prefix, the value will be false instead of
-      // the normal default of true. This avoids the need to put 
+      // the normal default of true. This avoids the need to put
       // "prefix = false" in every single unprefixed sound.
 
       if(def && explicitLumpName && cfg_size(section, ITEM_SND_PREFIX) == 0)
@@ -594,7 +598,7 @@ static void E_ProcessSound(sfxinfo_t *sfx, cfg_t *section, bool def)
       // haleyjd 06/03/06: change defaults for linkvol/linkpitch
       setLink = true;
    }
-   
+
    // haleyjd 09/24/06: process alias
    if(IS_SET(ITEM_SND_ALIAS))
    {
@@ -614,7 +618,7 @@ static void E_ProcessSound(sfxinfo_t *sfx, cfg_t *section, bool def)
 
       sfx->numrandomsounds = tempint;
 
-      sfx->randomsounds = 
+      sfx->randomsounds =
          ecalloc(sfxinfo_t **, sfx->numrandomsounds, sizeof(sfxinfo_t *));
 
       for(i = 0; i < sfx->numrandomsounds; ++i)
@@ -630,7 +634,7 @@ static void E_ProcessSound(sfxinfo_t *sfx, cfg_t *section, bool def)
       sfx->randomsounds    = NULL;
       sfx->numrandomsounds = 0;
    }
-   
+
    // process the skin index
    if(IS_SET(ITEM_SND_SKININDEX))
    {
@@ -698,10 +702,16 @@ static void E_ProcessSound(sfxinfo_t *sfx, cfg_t *section, bool def)
    // haleyjd 11/07/08: process explicit pc speaker lump name
    if(IS_SET(ITEM_SND_PCSLUMP))
    {
-      const char *s = cfg_getstr(section, ITEM_SND_PCSLUMP);
+      const char *lumpname = cfg_getstr(section, ITEM_SND_PCSLUMP);
 
-      if(s != NULL)
-         strncpy(sfx->pcslump, s, 9);
+      if(lumpname != NULL)
+      {
+         // alison: set the long file name if applicable
+         if(lumpname[0] == '/')
+            E_ReplaceString(sfx->pcslfn, estrdup(&lumpname[1]));
+         else
+            strncpy(sfx->pcslump, lumpname, 9);
+      }
    }
 
    // haleyjd 11/08/08: process "nopcsound" flag
@@ -734,14 +744,14 @@ void E_ProcessSounds(cfg_t *cfg)
    XL_ParseSoundInfo();
 
    E_EDFLogPuts("\t\tHashing sounds\n");
-      
+
    // now, let's collect the mnemonics (this must be done ahead of time)
    for(i = 0; i < numsfx; i++)
    {
       const char *mnemonic;
       cfg_t *sndsection = cfg_getnsec(cfg, EDF_SEC_SOUND, i);
       int idnum = cfg_getint(sndsection, ITEM_SND_DEHNUM);
-      
+
       mnemonic = cfg_title(sndsection);
 
       // if one already exists by this name, use it
@@ -766,7 +776,7 @@ void E_ProcessSounds(cfg_t *cfg)
       {
          // create a new sound
          sfx = estructalloc(sfxinfo_t, 1);
-         
+
          // verify the length
          if(strlen(mnemonic) >= sizeof(sfx->mnemonic))
          {
@@ -776,7 +786,7 @@ void E_ProcessSounds(cfg_t *cfg)
 
          // copy mnemonic
          strncpy(sfx->mnemonic, mnemonic, sizeof(sfx->mnemonic));
-         
+
          // add this sound to the hash table
          E_AddSoundToHash(sfx);
 
@@ -789,9 +799,9 @@ void E_ProcessSounds(cfg_t *cfg)
          // possibly add to numeric hash
          if(sfx->dehackednum > 0)
             E_AddSoundToDEHHash(sfx);
-      }            
+      }
    }
-      
+
    E_EDFLogPuts("\t\tProcessing data\n");
 
    // finally, process the individual sounds
@@ -844,7 +854,7 @@ void E_ProcessSoundDeltas(cfg_t *cfg, bool add)
 
       if(!sfx)
       {
-         E_EDFLoggedErr(2, 
+         E_EDFLoggedErr(2,
             "E_ProcessSoundDeltas: sound '%s' does not exist\n", tempstr);
       }
 
@@ -859,7 +869,7 @@ void E_ProcessSoundDeltas(cfg_t *cfg, bool add)
 // Sound Sequences
 //
 // haleyjd 05/28/06
-// 
+//
 
 #define ITEM_SEQ_ID     "id"
 #define ITEM_SEQ_CMDS   "cmds"
@@ -1001,7 +1011,7 @@ static void E_AddSequenceToNameHash(ESoundSeq_t *seq)
 //
 // E_AddSequenceToNumHash
 //
-// Adds an EDF sound sequence object to the numeric hash table. More than 
+// Adds an EDF sound sequence object to the numeric hash table. More than
 // one object with the same numeric id can exist, but E_SequenceForNum will
 // only ever find the first such object, which is always the last such
 // object added to the hash table.
@@ -1011,11 +1021,11 @@ static void E_AddSequenceToNameHash(ESoundSeq_t *seq)
 static void E_AddSequenceToNumHash(ESoundSeq_t *seq)
 {
    unsigned int idx;
-   
+
    if(seq->type != SEQ_ENVIRONMENT)
    {
       idx = seq->index % NUM_EDFSEQ_CHAINS;
-      
+
       seq->numlinks.insert(seq, &edf_seq_numchains[idx]);
 
       // possibly add to the specific type translation tables
@@ -1045,7 +1055,7 @@ static void E_AddSequenceToNumHash(ESoundSeq_t *seq)
 //
 // E_DelSequenceFromNumHash
 //
-// Removes a specific EDF sound sequence object from the numeric hash 
+// Removes a specific EDF sound sequence object from the numeric hash
 // table. This must be called on an object that's already linked before
 // relinking it.
 //
@@ -1167,7 +1177,7 @@ static int E_SeqGetAttn(const char *attnstr)
 
    if(attnstr)
    {
-      attn = E_StrToNumLinear(attenuation_types, NUM_ATTENUATION_TYPES, 
+      attn = E_StrToNumLinear(attenuation_types, NUM_ATTENUATION_TYPES,
                               attnstr);
       if(attn == NUM_ATTENUATION_TYPES)
          attn = ATTN_NORMAL;
@@ -1183,13 +1193,13 @@ static int E_SeqGetAttn(const char *attnstr)
 //
 // Generate a sound sequence opcode.
 //
-static void E_GenerateSeqOp(ESoundSeq_t *newSeq, tempcmd_t &tempcmd, 
+static void E_GenerateSeqOp(ESoundSeq_t *newSeq, tempcmd_t &tempcmd,
                             seqcmd_t *tempcmdbuf, unsigned int &allocused)
 {
    int cmdindex;
 
    // translate to command index
-   cmdindex = E_StrToNumLinear(sndseq_cmdstrs, SEQ_NUM_TXTCMDS, 
+   cmdindex = E_StrToNumLinear(sndseq_cmdstrs, SEQ_NUM_TXTCMDS,
                                tempcmd.strs[0]);
 
    // generate opcodes and their arguments in the temporary buffer
@@ -1291,8 +1301,8 @@ static void E_GenerateSeqOp(ESoundSeq_t *newSeq, tempcmd_t &tempcmd,
 //
 // Note that the commands are compiled into a temporary buffer that is allocated
 // at the upper bound of the possible code size -- no command compiles to more
-// than four bytecodes (one or two opcodes and two arguments). At the end, the 
-// temporary buffer is copied into one of the actually used size and the temp 
+// than four bytecodes (one or two opcodes and two arguments). At the end, the
+// temporary buffer is copied into one of the actually used size and the temp
 // buffer is destroyed.
 //
 static void E_ParseSeqCmds(cfg_t *cfg, ESoundSeq_t *newSeq)
@@ -1434,11 +1444,11 @@ static void E_ProcessSndSeq(cfg_t *cfg, unsigned int i)
          // If old key is >= 0, must remove from hash first
          if(newSeq->index >= 0)
             E_DelSequenceFromNumHash(newSeq);
-         
+
          // Set new key and type
          newSeq->index = idnum;
          newSeq->type  = type;
-         
+
          // If new key >= 0, add back to hash
          if(newSeq->index >= 0)
             E_AddSequenceToNumHash(newSeq);
@@ -1452,17 +1462,17 @@ static void E_ProcessSndSeq(cfg_t *cfg, unsigned int i)
       // verify length
       if(strlen(name) >= sizeof(newSeq->name))
          E_EDFLoggedErr(2, "E_ProcessSndSeq: invalid mnemonic '%s'\n", name);
-      
+
       // copy keys into sequence object
       strncpy(newSeq->name, name, sizeof(newSeq->name));
-      
+
       newSeq->index = idnum;
       newSeq->type  = type;
-            
+
       // add to hash tables
-      
+
       E_AddSequenceToNameHash(newSeq);
-      
+
       // numeric key is not required
       if(idnum >= 0)
          E_AddSequenceToNumHash(newSeq);
@@ -1545,7 +1555,7 @@ static void E_ResolveNames(cfg_t *cfg, unsigned int i)
 
    if(!seq)
    {
-      E_EDFLoggedErr(2, "E_ResolveNames: internal error: no such sequence %s\n", 
+      E_EDFLoggedErr(2, "E_ResolveNames: internal error: no such sequence %s\n",
                      name);
    }
 
@@ -1604,11 +1614,11 @@ static void E_ProcessEnviroMgr(cfg_t *cfg)
    {
       cfg_t *eseq = cfg_getsec(cfg, EDF_SEC_ENVIROMGR);
 
-      EnviroSeqManager.minStartWait = 
+      EnviroSeqManager.minStartWait =
          cfg_getint(eseq, ITEM_SEQMGR_MINSTARTWAIT);
       EnviroSeqManager.maxStartWait =
          cfg_getint(eseq, ITEM_SEQMGR_MAXSTARTWAIT);
-      
+
       // range check
       if(EnviroSeqManager.minStartWait < 0)
          EnviroSeqManager.minStartWait = 0;
@@ -1710,7 +1720,7 @@ static EAmbience_t *ambience_chains[NUMAMBIENCECHAINS];
 // Returns NULL if no such ambience object exists.
 //
 EAmbience_t *E_AmbienceForNum(int num)
-{   
+{
    int key = num % NUMAMBIENCECHAINS;
    EAmbience_t *cur = ambience_chains[key];
 
@@ -1795,7 +1805,7 @@ static void E_ProcessAmbienceSec(cfg_t *cfg, unsigned int i)
 
    // process attenuation
    tempstr = cfg_getstr(cfg, ITEM_AMB_ATTENUATION);
-   newAmb->attenuation = 
+   newAmb->attenuation =
       E_StrToNumLinear(attenuation_types, NUM_ATTENUATION_TYPES, tempstr);
    if(newAmb->attenuation == NUM_ATTENUATION_TYPES)
    {

--- a/source/mn_skinv.cpp
+++ b/source/mn_skinv.cpp
@@ -109,10 +109,7 @@ static void MN_skinEmulateAction(state_t *state)
 {
    if(state->action == A_PlaySoundEx)
    {
-      sfxinfo_t *sfx = E_ArgAsSound(state->args, 0);
-
-      if(sfx)
-         S_StartInterfaceSound(sfx->name);
+      S_StartInterfaceSound(E_ArgAsSound(state->args, 0));
    }
    else if(state->action == A_Pain)
    {
@@ -150,7 +147,7 @@ static void MN_skinEmulateAction(state_t *state)
       else
       {
          S_StartInterfaceSound(
-            ((GameModeInfo->flags & GIF_NODIEHI) || M_Random() % 2) ? 
+            ((GameModeInfo->flags & GIF_NODIEHI) || M_Random() % 2) ?
              players[consoleplayer].skin->sounds[sk_pldeth] :
              players[consoleplayer].skin->sounds[sk_pdiehi]);
       }
@@ -176,9 +173,9 @@ static void MN_skinEmulateAction(state_t *state)
 static void MN_SkinSetState(state_t *state)
 {
    int tics;
-   
+
    skview_state = state;
-   
+
    tics = skview_state->tics;
    skview_tics = menutime + (skview_halfspeed ? 2*tics : tics);
 
@@ -345,7 +342,7 @@ static void MN_SkinInstructions()
 
    // haleyjd 05/29/06: rewrote to be binding neutral and to draw all of
    // it with one call to V_FontWriteText instead of five.
-   V_FontWriteText(menu_font_normal, 
+   V_FontWriteText(menu_font_normal,
                "Instructions:\n"
                FC_GRAY "left"  FC_RED " = rotate left, "
                FC_GRAY "right" FC_RED " = rotate right\n"
@@ -355,7 +352,7 @@ static void MN_SkinInstructions()
                FC_GRAY "x"     FC_RED " = gib\n"
                FC_GRAY "space" FC_RED " = respawn, "
                FC_GRAY "h"     FC_RED " = half-speed\n"
-               FC_GRAY "toggle or previous" FC_RED " = exit", 
+               FC_GRAY "toggle or previous" FC_RED " = exit",
                4, INSTR_Y, &subscreen43);
 }
 
@@ -411,7 +408,7 @@ static void MN_SkinDrawer()
 
    // draw the sprite, with color translation and proper flipping
    // 01/12/04: changed translation handling
-   V_DrawPatchTranslatedLit(160, 120, &subscreen43, patch, translate, 
+   V_DrawPatchTranslatedLit(160, 120, &subscreen43, patch, translate,
                             colormaps[0] + 256 * lighttouse, flip);
 }
 
@@ -455,7 +452,7 @@ static void MN_initMetaDeaths()
    playerclass_t *pclass = players[consoleplayer].pclass;
    MetaTable     *meta   = mobjinfo[pclass->type]->meta;
    MetaState     *state  = NULL;
-   
+
    skview_metadeaths.clear();
 
    while((state = meta->getNextTypeEx(state)))
@@ -493,7 +490,7 @@ void MN_InitSkinViewer()
    skview_atkstate2 = pclass->altattack;
 
    // haleyjd 03/29/08: determine if player skin has wimpy death sound
-   skview_haswdth = 
+   skview_haswdth =
       (strcasecmp(players[consoleplayer].skin->sounds[sk_plwdth], "none") != 0);
 
    MN_SkinSetState(states[mobjinfo[skview_typenum]->seestate]);

--- a/source/s_formats.cpp
+++ b/source/s_formats.cpp
@@ -67,8 +67,8 @@ struct sounddata_t
 // S_checkDMXPadded
 //
 // Most canonical DMX samples are padded with 16 lead-in bytes and 16 lead-out
-// bytes. All such samples with this property have the 17th byte (the first 
-// real sample) equal in value to the first 16 bytes (and likewise, the 17th 
+// bytes. All such samples with this property have the 17th byte (the first
+// real sample) equal in value to the first 16 bytes (and likewise, the 17th
 // byte from the end is repeated 16 more times).
 //
 // We'll consider the sample to be in canonical padded form if it passes the
@@ -135,7 +135,7 @@ static bool S_isDMXSample(byte *data, size_t len, sounddata_t &sd)
 
 //=============================================================================
 //
-// Wave 
+// Wave
 //
 // There are a billion and one variants of the RIFF WAVE format. We accept only
 // so-called canonical waves in either 8- or 16-bit PCM, mono only.
@@ -309,7 +309,7 @@ static bool S_detectSoundFormat(sounddata_t &sd, byte *data, size_t len)
 //
 // S_alenForSample
 //
-// Calculate the "actual" sample length for a digital sound effect after 
+// Calculate the "actual" sample length for a digital sound effect after
 // conversion from its native samplerate to the samplerate used for output.
 //
 static unsigned int S_alenForSample(const sounddata_t &sd)
@@ -434,9 +434,11 @@ static void S_convertPCM16(sfxinfo_t *sfx, const sounddata_t &sd)
 //
 static int S_getSfxLumpNum(sfxinfo_t *sfx)
 {
-   char namebuf[16];
+   char namebuf[16] = { 0 };
 
-   memset(namebuf, 0, sizeof(namebuf));
+   // alison: check long file name
+   if(sfx->lfn)
+      return wGlobalDir.checkNumForLFNNSG(sfx->lfn, lumpinfo_t::ns_sounds);
 
    // haleyjd 09/03/03: determine whether to apply DS prefix to
    // name or not using new prefix flag
@@ -463,11 +465,11 @@ bool S_LoadDigitalSoundEffect(sfxinfo_t *sfx)
 {
    bool  res = false;
    int   lump = S_getSfxLumpNum(sfx);
-  
+
    // replace missing sounds with a reasonable default
    if(lump == -1)
       lump = wGlobalDir.getNumForNameNSG(GameModeInfo->defSoundName, lumpinfo_t::ns_sounds);
-   
+
    size_t lumplen = (size_t)wGlobalDir.lumpLength(lump);
    if(!lumplen)
       return false;
@@ -514,11 +516,11 @@ bool S_LoadDigitalSoundEffect(sfxinfo_t *sfx)
 void S_CacheDigitalSoundLump(sfxinfo_t *sfx)
 {
    int lump = S_getSfxLumpNum(sfx);
-   
+
    // replace missing sounds with a reasonable default
    if(lump == -1)
       lump = wGlobalDir.getNumForNameNSG(GameModeInfo->defSoundName, lumpinfo_t::ns_sounds);
-   
+
    wGlobalDir.cacheLumpNum(lump, PU_CACHE);
 }
 

--- a/source/s_sound.cpp
+++ b/source/s_sound.cpp
@@ -155,7 +155,7 @@ static void S_StopChannel(int cnum)
    if(c->sfxinfo)
    {
       I_StopSound(c->handle, c->idnum); // stop the sound playing
-      
+
       // haleyjd 09/27/06: clear the entire channel
       memset(c, 0, sizeof(channel_t));
    }
@@ -171,11 +171,11 @@ static bool S_CheckSectorKill(const sector_t *earsec, const PointThinker *src)
 {
    // haleyjd 05/29/06: moved up to here and fixed a major bug
    if(gamestate == GS_LEVEL)
-   { 
+   {
       // are we in a killed-sound sector?
       if(earsec && earsec->flags & SECF_KILLSOUND)
          return true;
-      
+
       // source in a killed-sound sector?
       if(src &&
          R_PointInSubsector(src->x, src->y)->sector->flags & SECF_KILLSOUND)
@@ -215,7 +215,7 @@ static int S_AdjustSoundParams(camera_t *listener, const PointThinker *source,
    if(!source)
       I_Error("S_AdjustSoundParams: NULL source\n");
 #endif
-   
+
    // calculate the distance to sound origin
    //  and clip it if necessary
    //
@@ -224,7 +224,7 @@ static int S_AdjustSoundParams(camera_t *listener, const PointThinker *source,
 
    sx = source->x;
    sy = source->y;
-      
+
    if(useportalgroups && listener->groupid != source->groupid)
    {
       // The listener and the source are not in the same subspace, so offset
@@ -236,7 +236,7 @@ static int S_AdjustSoundParams(camera_t *listener, const PointThinker *source,
 
    adx = D_abs((listener->x >> FRACBITS) - (sx >> FRACBITS));
    ady = D_abs((listener->y >> FRACBITS) - (sy >> FRACBITS));
-   
+
    if(ady > adx)
    {
       dist = adx;
@@ -245,8 +245,8 @@ static int S_AdjustSoundParams(camera_t *listener, const PointThinker *source,
    }
 
    dist = adx ? FixedDiv(adx, finesine[(tantoangle_acc[FixedDiv(ady,adx) >> DBITS]
-                                        + ANG90) >> ANGLETOFINESHIFT]) : 0;   
-   
+                                        + ANG90) >> ANGLETOFINESHIFT]) : 0;
+
    // haleyjd 05/29/06: allow per-channel volume scaling
    basevolume = (snd_SfxVolume * chanvol) / 15;
 
@@ -287,7 +287,7 @@ static int S_AdjustSoundParams(camera_t *listener, const PointThinker *source,
 
    // angle of source to listener
    // sf: use listenx, listeny
-   
+
    angle = R_PointToAngle2(listener->x, listener->y, sx, sy);
 
    if(angle <= listener->angle)
@@ -297,7 +297,7 @@ static int S_AdjustSoundParams(camera_t *listener, const PointThinker *source,
 
    // stereo separation
    *sep = NORM_SEP - FixedMul(S_STEREO_SWING >> FRACBITS, finesine[angle]);
-   
+
    // volume calculation
    *vol = dist < close_dist >> FRACBITS ? basevolume :
       basevolume * ((clipping_dist >> FRACBITS) - dist) / attenuator;
@@ -306,7 +306,7 @@ static int S_AdjustSoundParams(camera_t *listener, const PointThinker *source,
    // haleyjd 04/27/10: special treatment for priorities <= 0
    if(*pri > 0)
       *pri = *pri + (127 - *vol);
-   
+
    if(*pri > 255) // cap to 255
       *pri = 255;
 
@@ -360,7 +360,7 @@ static int S_getChannel(const PointThinker *origin, sfxinfo_t *sfxinfo,
          }
       }
    }
-   
+
    // Find an open channel
    if(cnum == numChannels)
    {
@@ -397,7 +397,7 @@ static int S_getChannel(const PointThinker *origin, sfxinfo_t *sfxinfo,
    if(cnum >= numChannels)
       I_Error("S_getChannel: handle %d out of range\n", cnum);
 #endif
-   
+
    return cnum;
 }
 
@@ -445,7 +445,7 @@ void S_StartSfxInfo(const soundparams_t &params)
    // haleyjd 09/03/03: allow NULL sounds to fall through
    if(!sfx)
       return;
-   
+
    //jff 1/22/98 return if sound is not enabled
    if(!snd_card || nosfxparm)
       return;
@@ -455,7 +455,7 @@ void S_StartSfxInfo(const soundparams_t &params)
    // serve as alternate names for the same sounds, in contrast to links which
    // provide a way of playing the same sound with different parameters.
 
-   // haleyjd 05/12/09: Randomized sounds. Like aliases, these are links to 
+   // haleyjd 05/12/09: Randomized sounds. Like aliases, these are links to
    // other sounds, but we choose one at random.
 
    sfxinfo_t *aliasinfo = sfx;
@@ -472,7 +472,7 @@ void S_StartSfxInfo(const soundparams_t &params)
       }
    }
 
-   // haleyjd:  we must weed out degenMobj's before trying to 
+   // haleyjd:  we must weed out degenMobj's before trying to
    // dereference these fields -- a thinker check perhaps?
    if((mo = thinker_cast<const Mobj *>(origin)))
    {
@@ -486,7 +486,7 @@ void S_StartSfxInfo(const soundparams_t &params)
 
          // haleyjd: monster skins don't support sound replacements
          if(mo->skin && mo->skin->type == SKIN_PLAYER)
-         {         
+         {
             sndname = mo->skin->sounds[sfx->skinsound - 1];
             sfx = S_SfxInfoForName(sndname);
          }
@@ -499,8 +499,8 @@ void S_StartSfxInfo(const soundparams_t &params)
       }
 
       // haleyjd: give local client sounds high priority
-      if(mo == players[displayplayer].mo || 
-         (mo->flags & MF_MISSILE && 
+      if(mo == players[displayplayer].mo ||
+         (mo->flags & MF_MISSILE &&
           mo->target == players[displayplayer].mo))
       {
          priority_boost = true;
@@ -526,7 +526,7 @@ void S_StartSfxInfo(const soundparams_t &params)
       if(volumeScale > chancount)
          volumeScale -= chancount;
    }
-   
+
    // haleyjd: modified so that priority value is always used
    // haleyjd: also modified to get and store proper singularity value
    // haleyjd: allow priority boost for local client sounds
@@ -535,7 +535,7 @@ void S_StartSfxInfo(const soundparams_t &params)
 
    // haleyjd: setup playercam
    if(gamestate == GS_LEVEL)
-   {     
+   {
       if(camera) // an external camera is active
       {
          playercam = *camera; // assign directly
@@ -549,8 +549,8 @@ void S_StartSfxInfo(const soundparams_t &params)
          // adjust sounds for a player that hasn't been spawned yet!
          if(pmo)
          {
-            playercam.x = pmo->x; 
-            playercam.y = pmo->y; 
+            playercam.x = pmo->x;
+            playercam.y = pmo->y;
             playercam.z = pmo->z;
             playercam.angle = pmo->angle;
             playercam.groupid = pmo->groupid;
@@ -572,7 +572,7 @@ void S_StartSfxInfo(const soundparams_t &params)
    // Check to see if it is audible, modify the params
    // killough 3/7/98, 4/25/98: code rearranged slightly
    // haleyjd 08/12/04: add extcamera check
-   
+
    if(!origin || (!extcamera && origin == players[displayplayer].mo))
    {
       sep = NORM_SEP;
@@ -582,7 +582,7 @@ void S_StartSfxInfo(const soundparams_t &params)
          return;
    }
    else
-   {     
+   {
       // use an external cam?
       if(!S_AdjustSoundParams(listener, origin, volumeScale, params.attenuation,
                               &volume, &sep, &pitch, &priority, sfx))
@@ -590,7 +590,7 @@ void S_StartSfxInfo(const soundparams_t &params)
       else if(origin->x == playercam.x && origin->y == playercam.y)
          sep = NORM_SEP;
    }
-  
+
    if(pitched_sounds)
    {
       switch(sfx->pitch_type)
@@ -645,7 +645,7 @@ void S_StartSfxInfo(const soundparams_t &params)
    if(handle >= 0)
    {
       channels[cnum].handle = handle;
-      
+
       // haleyjd 05/29/06: record volume scale value and attenuation type
       // haleyjd 06/03/06: record pitch too (wtf is going on here??)
       // haleyjd 09/27/06: store priority and singularity values (!!!)
@@ -670,7 +670,7 @@ void S_StartSfxInfo(const soundparams_t &params)
 // S_StartSoundAtVolume
 //
 // haleyjd 05/29/06: Actually, DOOM had a routine named this, but it was
-// removed, apparently by the BOOM team, because it was never used for 
+// removed, apparently by the BOOM team, because it was never used for
 // anything useful (it was always called with snd_SfxVolume...).
 //
 void S_StartSoundAtVolume(const PointThinker *origin, int sfx_id,
@@ -715,7 +715,7 @@ void S_StartSoundNameAtVolume(const PointThinker *origin, const char *name,
                               int volume, int attn, int subchannel)
 {
    soundparams_t params;
-   
+
    // haleyjd 03/17/03: allow NULL sound names to fall through
    if(!name)
       return;
@@ -756,7 +756,7 @@ static void S_StartSoundLooped(PointThinker *origin, char *name, int volume,
                                int attn, int subchannel)
 {
    soundparams_t params;
-   
+
    if(!name)
       return;
 
@@ -807,12 +807,29 @@ void S_StartInterfaceSound(const char *name)
 }
 
 //
+// S_StartInterfaceSound(sfxinfo_t *)
+//
+// Start an interface sound by sfxinfo.
+//
+void S_StartInterfaceSound(sfxinfo_t *sfx)
+{
+   soundparams_t params;
+
+   if((params.sfx = sfx))
+   {
+      params.setNormalDefaults(NULL);
+      params.reverb = false;
+      S_StartSfxInfo(params);
+   }
+}
+
+//
 // S_StopSound
 //
 void S_StopSound(const PointThinker *origin, int subchannel)
 {
    int cnum;
-   
+
    //jff 1/22/98 return if sound is not enabled
    if(!snd_card || nosfxparm)
       return;
@@ -867,7 +884,7 @@ static ereverb_t *s_currentEnvironment;
 static void S_updateEnvironment(sector_t *earsec)
 {
    ereverb_t *reverb;
-   
+
    if(!earsec || gamestate != GS_LEVEL)
       reverb = E_GetDefaultReverb();
    else
@@ -888,7 +905,7 @@ static void S_updateEnvironment(sector_t *earsec)
 void S_UpdateSounds(const Mobj *listener)
 {
    // sf: a camera_t holding the information about the player
-   camera_t playercam = { 0 }; 
+   camera_t playercam = { 0 };
    sector_t *earsec = NULL;
 
    //jff 1/22/98 return if sound is not enabled
@@ -998,7 +1015,7 @@ bool S_CheckSoundPlaying(const PointThinker *mo, sfxinfo_t *aliasinfo)
          }
       }
    }
-   
+
    return false;
 }
 
@@ -1059,8 +1076,8 @@ void S_SetSfxVolume(int volume)
 //
 
 sfxinfo_t *S_SfxInfoForName(const char *name)
-{   
-   // haleyjd 09/03/03: now calls down to master EDF sound hash   
+{
+   // haleyjd 09/03/03: now calls down to master EDF sound hash
    sfxinfo_t *sfx = E_SoundForName(name);
 
    // haleyjd 03/26/11: if not found, check for an implicit wad sound
@@ -1083,7 +1100,7 @@ sfxinfo_t *S_SfxInfoForName(const char *name)
 // S_Chgun
 //
 // Delinks the chgun sound effect when a DSCHGUN lump has been
-// detected. This allows the sound to be used separately without 
+// detected. This allows the sound to be used separately without
 // use of EDF.
 //
 void S_Chgun()
@@ -1141,14 +1158,14 @@ void S_ChangeMusic(musicinfo_t *music, int looping)
 
    // same as the one playing ?
    if(mus_playing == music)
-      return;  
+      return;
 
    // shutdown old music
    S_StopMusic();
 
    if(music->prefix)
    {
-      psnprintf(namebuf, sizeof(namebuf), "%s%s", 
+      psnprintf(namebuf, sizeof(namebuf), "%s%s",
                 GameModeInfo->musPrefix, music->name);
    }
    else
@@ -1164,12 +1181,12 @@ void S_ChangeMusic(musicinfo_t *music, int looping)
    // haleyjd: changed to PU_STATIC
    // julian: added lump length
 
-   music->data = wGlobalDir.cacheLumpNum(lumpnum, PU_STATIC);   
+   music->data = wGlobalDir.cacheLumpNum(lumpnum, PU_STATIC);
 
    if(music->data)
    {
       music->handle = I_RegisterSong(music->data, W_LumpLength(lumpnum));
-      
+
       // play it
       if(music->handle)
       {
@@ -1199,20 +1216,20 @@ void S_ChangeMusicNum(int musnum, int looping)
    musicinfo_t *music;
 
    // haleyjd 05/18/14: check for Tarnsman's random music
-   if(s_randmusic && 
+   if(s_randmusic &&
       musnum >= GameModeInfo->randMusMin && musnum <= GameModeInfo->randMusMax)
    {
       musnum = M_RangeRandomEx(GameModeInfo->randMusMin, GameModeInfo->randMusMax);
    }
-   
+
    if(musnum <= GameModeInfo->musMin || musnum >= GameModeInfo->numMusic)
    {
       doom_printf(FC_ERROR "Bad music number %d\n", musnum);
       return;
    }
-   
+
    music = &(GameModeInfo->s_music[musnum]);
-   
+
    S_ChangeMusic(music, looping);
 }
 
@@ -1232,9 +1249,9 @@ void S_StartMusic(int m_id)
 void S_ChangeMusicName(const char *name, int looping)
 {
    musicinfo_t *music;
-   
+
    music = S_MusicForName(name);
-   
+
    if(music)
       S_ChangeMusic(music, looping);
    else
@@ -1258,7 +1275,7 @@ void S_StopMusic()
    I_StopSong(mus_playing->handle);
    I_UnRegisterSong(mus_playing->handle);
    Z_Free(mus_playing->data);
-   
+
    mus_playing->data = NULL;
    mus_playing = NULL;
 }
@@ -1273,8 +1290,8 @@ void S_StopMusic()
 //
 // Doom
 //
-// Probably the most complicated music determination, between the 
-// original episodes and the addition of episode 4, which is all 
+// Probably the most complicated music determination, between the
+// original episodes and the addition of episode 4, which is all
 // over the place.
 //
 int S_MusicForMapDoom()
@@ -1294,7 +1311,7 @@ int S_MusicForMapDoom()
 
    int episode = eclamp(gameepisode, 1, 4);
    int map     = eclamp(gamemap,     1, 9);
-            
+
    // sf: simplified
    return episode < 4 ? mus_e1m1 + (episode-1)*9 + map-1 : spmus[map-1];
 }
@@ -1320,7 +1337,7 @@ int S_MusicForMapHtic()
    // ensure bounds just for safety
    int gep = eclamp(gameepisode, 1, 6);
    int gmp = eclamp(gamemap,     1, 9);
-     
+
    return H_Mus_Matrix[gep - 1][gmp - 1];
 }
 
@@ -1334,23 +1351,23 @@ int S_MusicForMapHtic()
 void S_Start()
 {
    int mnum;
-   
+
    S_StopSounds(false);
-   
+
    //jff 1/22/98 return if music is not enabled
    if(!mus_card || nomusicparm)
       return;
-   
+
    // start new music for the level
    mus_paused = 0;
-   
+
    if(!*LevelInfo.musicName && gamemap == 0)
    {
       // dont know what music to play
       // we need a default
       LevelInfo.musicName = GameModeInfo->defMusName;
    }
-   
+
    // sf: replacement music
    if(*LevelInfo.musicName)
       S_ChangeMusicName(LevelInfo.musicName, true);
@@ -1360,7 +1377,7 @@ void S_Start()
          mnum = idmusnum; //jff 3/17/98 reload IDMUS music if not -1
       else
          mnum = GameModeInfo->MusicForMap();
-         
+
       // start music
       S_ChangeMusicNum(mnum, true);
    }
@@ -1374,7 +1391,7 @@ void S_Start()
 int S_DoomMusicCheat(const char *buf)
 {
    int input = (buf[0] - '1') * 9 + (buf[1] - '1');
-          
+
    // jff 4/11/98: prevent IDMUS0x IDMUSx0 in DOOM I and greater than introa
    if(buf[0] < '1' || buf[1] < '1' || input > 31)
       return -1;
@@ -1415,7 +1432,7 @@ static void S_HookMusic(musicinfo_t *);
 
 //
 // S_Init
-// 
+//
 // Initializes sound stuff, including volume
 // Sets channels, SFX and music volume,
 //  allocates channel buffer, sets S_sfx lookup.
@@ -1452,7 +1469,7 @@ void S_Init(int sfxVolume, int musicVolume)
       return;
 
    S_SetMusicVolume(musicVolume);
-   
+
    // no sounds are playing, and they are not mus_paused
    mus_paused = 0;
 
@@ -1469,12 +1486,12 @@ void S_Init(int sfxVolume, int musicVolume)
 static void S_HookMusic(musicinfo_t *music)
 {
    int hashslot;
-   
-   if(!music || !music->name) 
+
+   if(!music || !music->name)
       return;
-   
+
    hashslot = sound_hash(music->name);
-   
+
    music->next = musicinfos[hashslot];
    musicinfos[hashslot] = music;
 }
@@ -1499,9 +1516,9 @@ musicinfo_t *S_MusicForName(const char *name)
    tempname.toUpper(); // uppercase for insensitivity
 
    // If the gamemode-dependent music prefix is present, skip past it
-   if(prefixlen > 0 && namelen > prefixlen && 
+   if(prefixlen > 0 && namelen > prefixlen &&
       tempname.findSubStr(GameModeInfo->musPrefix) == tempname.constPtr())
-   {      
+   {
       nameToUse = name + prefixlen;
       nameHasPrefix = true;
    }
@@ -1514,7 +1531,7 @@ musicinfo_t *S_MusicForName(const char *name)
    tempname = nameToUse;
 
    hashnum = sound_hash(tempname.constPtr());
-  
+
    for(mus = musicinfos[hashnum]; mus; mus = mus->next)
    {
       if(!tempname.strCaseCmp(mus->name))
@@ -1540,7 +1557,7 @@ musicinfo_t *S_MusicForName(const char *name)
       else
          lumpHasPrefix = true;
    }
-   
+
    // Not found? Create a new musicinfo if the indicated lump is found.
    if(lumpnum >= 0)
    {
@@ -1549,7 +1566,7 @@ musicinfo_t *S_MusicForName(const char *name)
       mus->prefix = lumpHasPrefix;
       S_HookMusic(mus);
    }
-   
+
    return mus;
 }
 
@@ -1610,7 +1627,7 @@ CONSOLE_COMMAND(s_playmusic, 0)
    // is missing
    if(music->prefix)
    {
-      psnprintf(namebuf, sizeof(namebuf), "%s%s", 
+      psnprintf(namebuf, sizeof(namebuf), "%s%s",
                 GameModeInfo->musPrefix, music->name);
    }
    else
@@ -1618,7 +1635,7 @@ CONSOLE_COMMAND(s_playmusic, 0)
 
    if(W_CheckNumForName(namebuf) < 0)
    {
-      C_Printf(FC_ERROR "Lump %s not found for music %s\a\n", namebuf, 
+      C_Printf(FC_ERROR "Lump %s not found for music %s\a\n", namebuf,
                Console.argv[0]->constPtr());
       return;
    }
@@ -1681,7 +1698,7 @@ static cell AMX_NATIVE_CALL sm_sectorsound(AMX *amx, cell *params)
    while((secnum = P_FindSectorFromTag(tag, secnum)) >= 0)
    {
       sector_t *sector = &sectors[secnum];
-      
+
       S_StartSoundName(&sector->soundorg, sndname);
    }
 
@@ -1703,11 +1720,11 @@ static cell AMX_NATIVE_CALL sm_sectorsoundnum(AMX *amx, cell *params)
       amx_RaiseError(amx, SC_ERR_GAMEMODE | SC_ERR_MASK);
       return -1;
    }
-   
+
    while((secnum = P_FindSectorFromTag(tag, secnum)) >= 0)
    {
       sector_t *sector = &sectors[secnum];
-      
+
       S_StartSound(&sector->soundorg, sndnum);
    }
 

--- a/source/s_sound.h
+++ b/source/s_sound.h
@@ -103,13 +103,14 @@ struct soundparams_t
 void S_StartSfxInfo(const soundparams_t &params);
 void S_StartSound(const PointThinker *origin, int sound_id);
 void S_StartSoundName(const PointThinker *origin, const char *name);
-void S_StartSoundAtVolume(const PointThinker *origin, int sfx_id, 
+void S_StartSoundAtVolume(const PointThinker *origin, int sfx_id,
                           int volume, int attn, int subchannel);
 void S_StartSoundNameAtVolume(const PointThinker *origin, const char *name,
                               int volume, int attn,
                               int subchannel);
 void S_StartInterfaceSound(int sound_id);
 void S_StartInterfaceSound(const char *name);
+void S_StartInterfaceSound(sfxinfo_t *sfx);
 
 // Stop sound for thing at <origin>
 void S_StopSound(const PointThinker *origin, int subchannel);

--- a/source/sdl/i_pcsound.cpp
+++ b/source/sdl/i_pcsound.cpp
@@ -90,67 +90,67 @@ static void PCSound_Mix_Callback(void *udata, Uint8 *stream, int len)
    int oldfreq;
    int i;
    int nsamples;
-   
-   // Number of samples is quadrupled, because of 16-bit and stereo   
+
+   // Number of samples is quadrupled, because of 16-bit and stereo
    nsamples = len / 4;
-   
+
    leftptr = (Sint16 *) stream;
    rightptr = ((Sint16 *) stream) + 1;
-    
-   // Fill the output buffer   
+
+   // Fill the output buffer
    for(i = 0; i < nsamples; i++)
    {
-      // Has this sound expired? If so, invoke the callback to get 
-      // the next frequency.      
-      while(current_remaining == 0) 
+      // Has this sound expired? If so, invoke the callback to get
+      // the next frequency.
+      while(current_remaining == 0)
       {
          oldfreq = current_freq;
-         
+
          // Get the next frequency to play
-         
+
          callback(&current_remaining, &current_freq);
-         
+
          if(current_freq != 0)
          {
             // Adjust phase to match to the new frequency.
             // This gives us a smooth transition between different tones,
-            // with no impulse changes.            
+            // with no impulse changes.
             phase_offset = (phase_offset * oldfreq) / current_freq;
          }
-         
+
          current_remaining = (current_remaining * mixing_freq) / 1000;
       }
-      
-      // Set the value for this sample.      
+
+      // Set the value for this sample.
       if(current_freq == 0)
       {
-         // Silence         
+         // Silence
          this_value = 0;
       }
-      else 
+      else
       {
          int frac;
-         
+
          // Determine whether we are at a peak or trough in the current
-         // sound.  Multiply by 2 so that frac % 2 will give 0 or 1 
+         // sound.  Multiply by 2 so that frac % 2 will give 0 or 1
          // depending on whether we are at a peak or trough.
-         
+
          frac = (phase_offset * current_freq * 2) / mixing_freq;
-         
-         if((frac % 2) == 0) 
+
+         if((frac % 2) == 0)
             this_value =  SQUARE_WAVE_AMP;
          else
             this_value = -SQUARE_WAVE_AMP;
-         
+
          ++phase_offset;
       }
-      
+
       --current_remaining;
-      
-      // Use the same value for the left and right channels.      
+
+      // Use the same value for the left and right channels.
       *leftptr  += this_value;
       *rightptr += this_value;
-      
+
       leftptr  += 2;
       rightptr += 2;
    }
@@ -169,15 +169,15 @@ static int PCSound_SDL_Init(pcsound_callback_func callback_func)
       fprintf(stderr, "Unable to set up sound.\n");
       return 0;
    }
-   
+
    if(Mix_OpenAudio(pcsound_sample_rate, AUDIO_S16SYS, 2, 1024) < 0)
    {
       fprintf(stderr, "Error initialising SDL_mixer: %s\n", Mix_GetError());
-      
+
       SDL_QuitSubSystem(SDL_INIT_AUDIO);
       return 0;
    }
-   
+
    SDL_PauseAudio(0);
 
     // Get the mixer frequency, format and number of channels.
@@ -188,7 +188,7 @@ static int PCSound_SDL_Init(pcsound_callback_func callback_func)
 
     if (mixing_format != AUDIO_S16SYS || mixing_channels != 2)
     {
-        fprintf(stderr, 
+        fprintf(stderr,
                 "PCSound_SDL only supports native signed 16-bit LSB, "
                 "stereo format!\n");
 
@@ -221,7 +221,7 @@ static unsigned int current_sound_remaining = 0;
 static int current_sound_handle = 0;
 static int current_sound_lump_num = -1;
 
-static const float frequencies[] = 
+static const float frequencies[] =
 {
        0.0f,  175.00f,  180.02f,  185.01f,  190.02f,  196.02f,  202.02f,  208.01f,
     214.02f,  220.02f,  226.02f,  233.04f,  240.02f,  247.03f,  254.03f,  262.00f,
@@ -247,25 +247,25 @@ static const float frequencies[] =
 static void PCSCallbackFunc(int *duration, int *freq)
 {
    unsigned int tone;
-   
+
    *duration = 1000 / 140;
-   
+
    if(SDL_LockMutex(sound_lock) < 0)
    {
       *freq = 0;
       return;
    }
-   
+
    if(current_sound_lump != NULL && current_sound_remaining > 0)
    {
       // Read the next tone
-      
+
       tone = *current_sound_pos;
-      
+
       // Use the tone -> frequency lookup table.  See pcspkr10.zip
       // for a full discussion of this.
       // Check we don't overflow the frequency table.
-      
+
       if(tone < NUMFREQUENCIES)
       {
          *freq = (int) frequencies[tone];
@@ -274,28 +274,33 @@ static void PCSCallbackFunc(int *duration, int *freq)
       {
          *freq = 0;
       }
-      
+
       ++current_sound_pos;
       --current_sound_remaining;
    }
    else
       *freq = 0;
-   
+
    SDL_UnlockMutex(sound_lock);
 }
 
 static int I_PCSGetSfxLumpNum(sfxinfo_t *sfx)
 {
    int lumpnum = -1;
-   char soundName[9] = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+   char soundName[9] = { 0 };
    bool nameToTry = false;
 
-   // 1. use explicit PC speaker sound name if provided
-   // 2. if sound name is prefixed, use DP%s
-   // 3. if sound name starts with DS, replace DS with DP
+   // 1. use explicit PC speaker long file name if provided
+   // 2. use explicit PC speaker sound name if provided
+   // 3. if sound name is prefixed, use DP%s
+   // 4. if sound name starts with DS, replace DS with DP
    // Otherwise, there is no locatable PC speaker sound for this effect
 
-   if(sfx->pcslump[0] != '\0')
+   if(sfx->pcslfn)
+   {
+      lumpnum = wGlobalDir.checkNumForLFNNSG(sfx->pcslfn, lumpinfo_t::ns_sounds);
+   }
+   else if(sfx->pcslump[0] != '\0')
    {
       nameToTry = true;
       psnprintf(soundName, 9, "%s", sfx->pcslump);
@@ -305,7 +310,7 @@ static int I_PCSGetSfxLumpNum(sfxinfo_t *sfx)
       nameToTry = true;
       psnprintf(soundName, 9, "DP%s", sfx->name);
    }
-   else if(ectype::toUpper(sfx->name[0]) == 'D' && 
+   else if(ectype::toUpper(sfx->name[0]) == 'D' &&
            ectype::toUpper(sfx->name[1]) == 'S')
    {
       nameToTry = true;
@@ -323,38 +328,38 @@ static bool CachePCSLump(sfxinfo_t *sfx)
    int lumpnum;
    int lumplen;
    int headerlen;
-   
-   // Free the current sound lump back to the cache   
+
+   // Free the current sound lump back to the cache
    if(current_sound_lump != NULL)
    {
       Z_ChangeTag(current_sound_lump, PU_CACHE);
       current_sound_lump = NULL;
    }
-   
+
    // Load from WAD
-   
+
    // haleyjd: check for validity
    if((lumpnum = I_PCSGetSfxLumpNum(sfx)) == -1)
       return false;
 
    current_sound_lump = (Uint8 *)(wGlobalDir.cacheLumpNum(lumpnum, PU_STATIC));
    lumplen            = W_LumpLength(lumpnum);
-   
-   // Read header   
+
+   // Read header
 
    if(current_sound_lump[0] != 0x00 || current_sound_lump[1] != 0x00)
       return false;
-   
+
    headerlen = (current_sound_lump[3] << 8) | current_sound_lump[2];
-   
+
    if(headerlen > lumplen - 4)
       return false;
-   
-   // Header checks out ok   
+
+   // Header checks out ok
    current_sound_remaining = headerlen;
    current_sound_pos       = current_sound_lump + 4;
    current_sound_lump_num  = lumpnum;
-   
+
    return true;
 }
 
@@ -365,13 +370,13 @@ static bool CachePCSLump(sfxinfo_t *sfx)
 
 static int I_PCSInitSound()
 {
-   // Use the sample rate from the configuration file   
+   // Use the sample rate from the configuration file
    PCSound_SetSampleRate(44100);
-   
+
    // Initialise the PC speaker subsystem.
-   
+
    pcs_initialised = !!PCSound_SDL_Init(PCSCallbackFunc);
-   
+
    if(pcs_initialised)
    {
       sound_lock = SDL_CreateMutex();
@@ -379,7 +384,7 @@ static int I_PCSInitSound()
    }
    else
       printf("Failed to initialize PC speaker emulation\n");
-   
+
    return pcs_initialised;
 }
 
@@ -404,7 +409,7 @@ static void I_PCSShutdownSound()
       PCSound_SDL_Shutdown();
 }
 
-static int I_PCSStartSound(sfxinfo_t *sfx, int cnum, int vol, int sep, 
+static int I_PCSStartSound(sfxinfo_t *sfx, int cnum, int vol, int sep,
                           int pitch, int pri, int loop, bool reverb)
 {
    int result;
@@ -440,7 +445,7 @@ static void I_PCSStopSound(int handle, int id)
    if(SDL_LockMutex(sound_lock) < 0)
       return;
 
-   // If this is the channel currently playing, immediately end it.   
+   // If this is the channel currently playing, immediately end it.
    if(current_sound_handle == handle)
       current_sound_remaining = 0;
 

--- a/source/sounds.h
+++ b/source/sounds.h
@@ -109,7 +109,7 @@ struct sfxinfo_t
    void *data;        // sound data
    int length;        // lump length
    unsigned int alen; // length of converted sound pointed to by data
-   
+
    // this is checked every second to see if sound
    // can be thrown out (if 0, then decrement, if -1,
    // then throw out, if > 0, then it is in use)
@@ -117,7 +117,10 @@ struct sfxinfo_t
 
    // haleyjd: EDF mnemonic
    char mnemonic[129];
-      
+
+   char *lfn;    // alison: long file name
+   char *pcslfn; // alison: long file name for PC speaker sound
+
    // haleyjd 09/03/03: revised for dynamic EDF sounds
    DLListItem<sfxinfo_t> numlinks; // haleyjd 04/13/08: numeric hash links
    sfxinfo_t *next;                // next in mnemonic hash chain
@@ -135,16 +138,16 @@ struct musicinfo_t
 
    // haleyjd 04/10/11: whether to apply prefix or not
    bool prefix;
-   
+
    // lump number of music
    //  int lumpnum;
-   
+
    // music data
    void *data;
-   
+
    // music handle once registered
    int handle;
-   
+
    // sf: for hashing
    musicinfo_t *next;
 };

--- a/source/w_wad.cpp
+++ b/source/w_wad.cpp
@@ -19,7 +19,7 @@
 //
 
 #ifdef _MSC_VER
-// for Visual C++: 
+// for Visual C++:
 #include "Win32/i_opndir.h"
 #else
 // for SANE compilers:
@@ -239,7 +239,7 @@ void WadDirectory::handleOpenError(openwad_t &openData,
 //
 // WadDirectory::openFile
 //
-// haleyjd 04/06/11: For normal wad files, the file needs to be found and 
+// haleyjd 04/06/11: For normal wad files, the file needs to be found and
 // opened.
 //
 WadDirectory::openwad_t WadDirectory::openFile(const wfileadd_t &addInfo) const
@@ -247,7 +247,7 @@ WadDirectory::openwad_t WadDirectory::openFile(const wfileadd_t &addInfo) const
    edefstructvar(openwad_t, openData);
    qstring   filename;
    bool      allowInexact = (addInfo.flags & WFA_ALLOWINEXACTFN) == WFA_ALLOWINEXACTFN;
-   
+
    // Try opening the file
    filename = addInfo.filename;
    if(!(openData.handle = W_TryOpenFile(filename, allowInexact)))
@@ -260,7 +260,7 @@ WadDirectory::openwad_t WadDirectory::openFile(const wfileadd_t &addInfo) const
    openData.format = W_DetermineFileFormat(openData.handle, 0);
 
    // Check against format requirements
-   if(addInfo.flags & WFA_REQUIREFORMAT && 
+   if(addInfo.flags & WFA_REQUIREFORMAT &&
       openData.format != addInfo.requiredFmt)
    {
       handleOpenError(openData, addInfo, filename.constPtr());
@@ -347,7 +347,7 @@ bool WadDirectory::addMemoryWad(openwad_t &openData, const wfileadd_t &addInfo,
    // haleyjd 04/07/11
    wadinfo_t    header;
    ZAutoBuffer  fileinfo2free; // killough
-   filelump_t  *fileinfo; 
+   filelump_t  *fileinfo;
    size_t       length;
    size_t       info_offset;
    lumpinfo_t  *lump_p;
@@ -360,7 +360,7 @@ bool WadDirectory::addMemoryWad(openwad_t &openData, const wfileadd_t &addInfo,
 
    // allocate enough fileinfo_t's to hold the wad directory
    length = header.numlumps * sizeof(filelump_t);
-  
+
    fileinfo2free.alloc(length, true);              // killough
    fileinfo = fileinfo2free.getAs<filelump_t *>();
 
@@ -398,7 +398,7 @@ bool WadDirectory::addMemoryWad(openwad_t &openData, const wfileadd_t &addInfo,
       // setup for memory IO
       lump_p->memory.data     = openData.base;
       lump_p->memory.position = (size_t)(SwapLong(fileinfo->filepos));
-      
+
       lump_p->li_namespace = addInfo.li_namespace;     // killough 4/17/98
 
       strncpy(lump_p->name, fileinfo->name, 8);
@@ -424,7 +424,7 @@ bool WadDirectory::addWadFile(openwad_t &openData, const wfileadd_t &addInfo,
    long         baseoffset = static_cast<long>(addInfo.baseoffset);
    wadinfo_t    header;
    ZAutoBuffer  fileinfo2free; // killough
-   filelump_t  *fileinfo; 
+   filelump_t  *fileinfo;
    size_t       length;
    long         info_offset;
    lumpinfo_t  *lump_p;
@@ -459,7 +459,7 @@ bool WadDirectory::addWadFile(openwad_t &openData, const wfileadd_t &addInfo,
          else
             C_Printf(FC_ERROR "Failed reading header for wad file %s", openData.filename);
 
-         return false;            
+         return false;
       }
    }
 
@@ -472,7 +472,7 @@ bool WadDirectory::addWadFile(openwad_t &openData, const wfileadd_t &addInfo,
 
    // allocate enough fileinfo_t's to hold the wad directory
    length = header.numlumps * sizeof(filelump_t);
-  
+
    fileinfo2free.alloc(length, true);              // killough
    fileinfo = fileinfo2free.getAs<filelump_t *>();
 
@@ -514,7 +514,7 @@ bool WadDirectory::addWadFile(openwad_t &openData, const wfileadd_t &addInfo,
          W_CheckDirectoryHacks(wadHash, fileinfo, header.numlumps);
    }
 
-   // update IWAD handle? 
+   // update IWAD handle?
    // haleyjd: Must be a public wad file.
    if(!(addInfo.flags & WFA_PRIVATE) && this->ispublic)
    {
@@ -546,7 +546,7 @@ bool WadDirectory::addWadFile(openwad_t &openData, const wfileadd_t &addInfo,
       // for subfiles, add baseoffset to the lump offset
       if(addInfo.flags & WFA_SUBFILE)
          lump_p->direct.position += static_cast<size_t>(baseoffset);
-      
+
       lump_p->li_namespace = addInfo.li_namespace;     // killough 4/17/98
 
       strncpy(lump_p->name, fileinfo->name, 8);
@@ -585,7 +585,7 @@ bool WadDirectory::addZipFile(openwad_t &openData,
       return true;
    }
 
-   // update IWAD handle? 
+   // update IWAD handle?
    if(!(addInfo.flags & WFA_PRIVATE) && this->ispublic)
    {
       if(IWADSource < 0 && (addInfo.flags & WFA_ISIWADFILE))
@@ -636,7 +636,7 @@ bool WadDirectory::addZipFile(openwad_t &openData,
 //
 // WadDirectory::addFile
 //
-// All files are optional, but at least one file must be found (PWAD, if all 
+// All files are optional, but at least one file must be found (PWAD, if all
 // required lumps are present).
 // Files with a .wad extension are wadlink files with multiple lumps.
 // Other files are single lumps with the base filename for the lump name.
@@ -649,7 +649,7 @@ bool WadDirectory::addFile(wfileadd_t &addInfo)
    // Directory file addition callback type
    typedef bool (WadDirectory::* AddFileCB)(openwad_t &, const wfileadd_t &,
                                             int);
-   
+
    static AddFileCB fileadders[W_FORMAT_MAX] =
    {
       &WadDirectory::addWadFile,             // W_FORMAT_WAD
@@ -657,17 +657,17 @@ bool WadDirectory::addFile(wfileadd_t &addInfo)
       &WadDirectory::addSingleFile,          // W_FORMAT_FILE
       &WadDirectory::addDirectoryAsArchive   // W_FORMAT_DIR
    };
-   
+
    edefstructvar(openwad_t, openData);
 
    // When loading a subfile, the physical file is already open.
    if(addInfo.flags & WFA_SUBFILE)
-   {      
+   {
       openData.filename = addInfo.filename;
       openData.handle   = addInfo.f;
 
       // Only WAD files are currently supported as subfiles.
-      if(W_DetermineFileFormat(openData.handle, 
+      if(W_DetermineFileFormat(openData.handle,
             static_cast<long>(addInfo.baseoffset)) != W_FORMAT_WAD)
       {
          addInfo.flags |= WFA_OPENFAILFATAL;
@@ -693,12 +693,12 @@ bool WadDirectory::addFile(wfileadd_t &addInfo)
       // Open the physical archive file and determine its format
       openData = openFile(addInfo);
       if(openData.error)
-         return false; 
+         return false;
    }
 
-   // Show adding message if at startup and not a private directory or 
+   // Show adding message if at startup and not a private directory or
    // in-memory wad
-   if(!(addInfo.flags & (WFA_PRIVATE|WFA_INMEMORY)) && 
+   if(!(addInfo.flags & (WFA_PRIVATE|WFA_INMEMORY)) &&
       this->ispublic && in_textmode)
    {
       printf(" adding %s\n", openData.filename);   // killough 8/8/98
@@ -715,7 +715,7 @@ bool WadDirectory::addFile(wfileadd_t &addInfo)
       handleOpenError(openData, addInfo, openData.filename);
       return false;
    }
-   
+
    return true; // no error
 }
 
@@ -738,13 +738,13 @@ int WadDirectory::addDirectory(const char *dirpath)
    int     localcount = 0;
    int     totalcount = 0;
    int     startlump;
-   int     usinglump  = 0; 
+   int     usinglump  = 0;
    int     globallump = 0;
    size_t  i, fileslen;
 
    PODCollection<dirfile_t> files;
    lumpinfo_t *newlumps;
-   
+
    if(!(dir = opendir(dirpath)))
       return 0;
 
@@ -756,7 +756,7 @@ int WadDirectory::addDirectory(const char *dirpath)
 
       if(!strcmp(ent->d_name, ".")  || !strcmp(ent->d_name, ".."))
          continue;
-      
+
       newfile.fullfn = M_SafeFilePath(dirpath, ent->d_name);
 
       if(!stat(newfile.fullfn, &sbuf)) // check for existence
@@ -769,11 +769,11 @@ int WadDirectory::addDirectory(const char *dirpath)
             newfile.size  = (size_t)(sbuf.st_size);
             ++localcount;
          }
-      
+
          files.add(newfile);
       }
    }
-   
+
    closedir(dir);
 
    fileslen = files.getLength();
@@ -796,7 +796,7 @@ int WadDirectory::addDirectory(const char *dirpath)
 
    // create lumpinfo_t structures for the files
    newlumps = estructalloc(lumpinfo_t, localcount);
-   
+
    // keep track of this allocation of lumps
    addInfoPtr(newlumps);
 
@@ -805,7 +805,7 @@ int WadDirectory::addDirectory(const char *dirpath)
       if(!files[i].isdir)
       {
          lumpinfo_t *lump = &newlumps[usinglump++];
-         
+
          M_ExtractFileBase(files[i].fullfn, lump->name);
          M_Strupr(lump->name);
          lump->li_namespace = lumpinfo_t::ns_global; // TODO
@@ -1092,7 +1092,7 @@ protected:
    }
 
 public:
-   WadNamespace() 
+   WadNamespace()
       : inMarkers(false), nsdata(nullptr), marked(), numMarked(0)
    {
    }
@@ -1101,9 +1101,9 @@ public:
    void setNSData(nsdata_t *pNsData) { nsdata = pNsData; }
 
    // Add a lump into this namespace
-   void addLump(lumpinfo_t *lump) 
+   void addLump(lumpinfo_t *lump)
    {
-      marked.add(lump); 
+      marked.add(lump);
       lump->li_namespace = nsdata->li_namespace;
       ++numMarked;
    }
@@ -1516,7 +1516,7 @@ void WadDirectory::initMultipleFiles(wfileadd_t *files)
    type     = NORMAL; // Not a managed directory
 
    curfile = files;
-   
+
    // open all the files, load headers, and count lumps
    while(curfile->filename)
    {
@@ -1531,10 +1531,10 @@ void WadDirectory::initMultipleFiles(wfileadd_t *files)
 
       ++curfile;
    }
-   
+
    if(!numlumps)
       I_Error("WadDirectory::InitMultipleFiles: no files found\n");
-   
+
    initResources();
 }
 
@@ -1604,7 +1604,7 @@ void WadDirectory::readLump(int lump, void *dest,
 {
    size_t c;
    lumpinfo_t *lptr;
-   
+
    if(lump < 0 || lump >= numlumps)
       I_Error("WadDirectory::ReadLump: %d >= numlumps\n", lump);
 
@@ -1619,7 +1619,7 @@ void WadDirectory::readLump(int lump, void *dest,
    c = LumpHandlers[lptr->type].readLump(lptr, dest);
    if(c < lptr->size)
    {
-      I_Error("WadDirectory::readLump: only read %d of %d on lump %d\n", 
+      I_Error("WadDirectory::readLump: only read %d of %d on lump %d\n",
               (int)c, (int)lptr->size, lump);
    }
 
@@ -1637,9 +1637,9 @@ void WadDirectory::readLump(int lump, void *dest,
       default:
          break;
       }
- 
+
       // Does the formatter want us to bomb out in response to an error?
-      if(code == WadLumpLoader::CODE_FATAL) 
+      if(code == WadLumpLoader::CODE_FATAL)
          I_Error("WadDirectory::readLump: lump %s is malformed\n", lptr->name);
    }
 }
@@ -1660,25 +1660,25 @@ void *WadDirectory::cacheLumpNum(int lump, int tag,
    // haleyjd 08/14/02: again, should not be RANGECHECK only
    if(lump < 0 || lump >= numlumps)
       I_Error("WadDirectory::CacheLumpNum: %i >= numlumps\n", lump);
-   
+
    if(!(lumpinfo[lump]->cache[fmt]))      // read the lump in
    {
-      readLump(lump, 
-               Z_Malloc(lumpLength(lump), tag, &(lumpinfo[lump]->cache[fmt])), 
+      readLump(lump,
+               Z_Malloc(lumpLength(lump), tag, &(lumpinfo[lump]->cache[fmt])),
                lfmt);
    }
    else
    {
-      // haleyjd: do not lower cache level and cause static users to lose their 
-      // data unexpectedly (ie, do not change PU_STATIC into PU_CACHE -- that 
+      // haleyjd: do not lower cache level and cause static users to lose their
+      // data unexpectedly (ie, do not change PU_STATIC into PU_CACHE -- that
       // must be done using Z_ChangeTag explicitly)
-      
+
       int oldtag = Z_CheckTag(lumpinfo[lump]->cache[fmt]);
 
-      if(tag < oldtag) 
+      if(tag < oldtag)
          Z_ChangeTag(lumpinfo[lump]->cache[fmt], tag);
    }
-   
+
    return lumpinfo[lump]->cache[fmt];
 }
 
@@ -1729,8 +1729,8 @@ bool WadDirectory::writeLump(const char *lumpname, const char *destpath) const
 {
    int    lumpnum;
    size_t size;
-   
-   if((lumpnum = checkNumForName(lumpname)) >= 0 && 
+
+   if((lumpnum = checkNumForName(lumpname)) >= 0 &&
       (size    = lumpinfo[lumpnum]->size  ) >  0)
    {
       ZAutoBuffer lumpData(size, false);
@@ -1763,11 +1763,11 @@ uint32_t W_LumpCheckSum(int lumpnum)
 // haleyjd 06/26/09
 // Frees all the lumps cached in a private directory.
 //
-// Note that it's necessary to use Z_Free and not Z_ChangeTag 
-// on all resources loaded from a private wad directory if the 
+// Note that it's necessary to use Z_Free and not Z_ChangeTag
+// on all resources loaded from a private wad directory if the
 // directory is destroyed. Otherwise the zone heap will maintain
-// dangling pointers into the freed wad directory, and heap 
-// corruption would occur at a seemingly random time after an 
+// dangling pointers into the freed wad directory, and heap
+// corruption would occur at a seemingly random time after an
 // arbitrary Z_Malloc call freed the cached resources.
 //
 void WadDirectory::freeDirectoryLumps()
@@ -1890,7 +1890,7 @@ static size_t W_FileReadLump(lumpinfo_t *l, void *dest)
       sizeread = fread(dest, 1, size, f);
       fclose(f);
    }
-   
+
    return sizeread;
 }
 

--- a/source/w_wad.h
+++ b/source/w_wad.h
@@ -53,7 +53,7 @@ struct directlump_t
    FILE *file;       // for a direct lump, a pointer to the file it is in
    size_t position;  // for direct and memory lumps, offset into file/buffer
 };
-  
+
 // A memory lump is loaded in a buffer in RAM and just needs to be memcpy'd.
 struct memorylump_t
 {
@@ -79,7 +79,7 @@ struct lumpinfo_t
    // haleyjd: logical lump data
    char   name[9];
    size_t size;
-   
+
    // killough 1/31/98: hash table fields, used for ultra-fast hash table lookup
    int index, next;
 
@@ -88,7 +88,7 @@ struct lumpinfo_t
    int selfindex;
 
    // killough 4/17/98: namespace tags, to prevent conflicts between resources
-   enum 
+   enum
    {
       ns_global,
       ns_MIN_LOCAL,
@@ -114,7 +114,7 @@ struct lumpinfo_t
       fmt_patch,   // converted to a patch
       fmt_maxfmts  // number of formats
    } lumpformat;
-   
+
    void *cache[fmt_maxfmts];  //sf
 
    // haleyjd: lump type
@@ -125,11 +125,11 @@ struct lumpinfo_t
       lump_file,    // lump is a directory file; must be opened to use
       lump_zip,     // lump is inside a zip file
       lump_numtypes
-   }; 
+   };
    int type;
 
    int source; // haleyjd: unique id # for source of this lump
-   
+
    // haleyjd: physical lump data (guarded union)
    union
    {
@@ -181,7 +181,7 @@ struct wfileadd_t
 //
 // haleyjd 06/26/11: Wad lump preprocessing and formatting
 //
-// Inherit from this interface class to provide verification and preprocessing 
+// Inherit from this interface class to provide verification and preprocessing
 // code to W_CacheLump* routines.
 //
 class WadLumpLoader
@@ -196,13 +196,13 @@ public:
    } Code;
 
    // verifyData should do format checking and return true if the data is valid,
-   // and false otherwise. If verifyData returns anything other than CODE_OK, 
+   // and false otherwise. If verifyData returns anything other than CODE_OK,
    // formatData is not called under any circumstance.
    virtual Code verifyData(lumpinfo_t *lump) const { return CODE_OK; }
 
    // formatData should do preprocessing work on the lump. This work will be
    // retained until the wad lump is freed from cache, so it allows such work to
-   // be done once only and not every time the lump is referenced/used. 
+   // be done once only and not every time the lump is referenced/used.
    virtual Code formatData(lumpinfo_t *lump) const { return CODE_OK; }
 
    // formatIndex specifies an alternate cache pointer to use for resources
@@ -235,7 +235,7 @@ public:
       ADDSUBFILE, // Add as a subfile wad
       ADDPRIVATE  // Add to a private directory
    };
-   
+
    static int IWADSource;   // source # of the global IWAD file
    static int ResWADSource; // source # of the resource wad (ie. eternity.wad)
 
@@ -337,7 +337,7 @@ public:
    // Accessors
    int   getType() const  { return type; }
    void  setType(int i)   { type = i;    }
-   
+
    // Read-only properties
    int          getNumLumps() const { return numlumps; }
    lumpinfo_t **getLumpInfo() const { return lumpinfo; }


### PR DESCRIPTION
This allows EDF sound definitions to use long file names, for example:
```
sound mpistolf {lump "/lsounds/pistol/fire.wav"}
```

Apologies for the extraneous whitespace removal in w_wad.cpp.