### PR TITLE
Added "viewheight" playerclass property

### DIFF
--- a/source/e_player.cpp
+++ b/source/e_player.cpp
@@ -107,6 +107,7 @@ cfg_opt_t edf_skin_opts[] =
 #define ITEM_PCLASS_INITIALHEALTH  "initialhealth"
 #define ITEM_PCLASS_MAXHEALTH      "maxhealth"
 #define ITEM_PCLASS_SUPERHEALTH    "superhealth"
+#define ITEM_PCLASS_VIEWHEIGHT     "viewheight"
 #define ITEM_PCLASS_SPEEDWALK      "speedwalk"
 #define ITEM_PCLASS_SPEEDRUN       "speedrun"
 #define ITEM_PCLASS_SPEEDSTRAFE    "speedstrafe"
@@ -150,6 +151,7 @@ static cfg_opt_t reborn_opts[] =
    CFG_INT(ITEM_PCLASS_INITIALHEALTH, 100,  CFGF_NONE),  \
    CFG_INT(ITEM_PCLASS_MAXHEALTH,     100,  CFGF_NONE),  \
    CFG_INT(ITEM_PCLASS_SUPERHEALTH,   100,  CFGF_NONE),  \
+   CFG_FLOAT(ITEM_PCLASS_VIEWHEIGHT,  41.0, CFGF_NONE),  \
                                                          \
    /* speeds */                                          \
    CFG_INT(ITEM_PCLASS_SPEEDWALK,      0x19, CFGF_NONE), \
@@ -669,6 +671,9 @@ static void E_processPlayerClass(cfg_t *pcsec, bool delta)
       else  // either new and specified or old and specified
          pc->superhealth = cfg_getint(pcsec, ITEM_PCLASS_SUPERHEALTH);
    }
+   // view height
+   if (IS_SET(pcsec, ITEM_PCLASS_VIEWHEIGHT))
+      pc->viewheight = M_DoubleToFixed(cfg_getfloat(pcsec, ITEM_PCLASS_VIEWHEIGHT));
 
    // process player speed fields
 

--- a/source/e_player.h
+++ b/source/e_player.h
@@ -67,6 +67,7 @@ struct playerclass_t
    int initialhealth;    // initial health when reborn
    int maxhealth;        // max health for regular items, HealThing and Gauntlets
    int superhealth;      // max health for superchargers and HealThing
+   fixed_t viewheight;   // [XA] view height, relative to player's 'z' position
 
    // speeds
    fixed_t forwardmove[2];

--- a/source/p_map.cpp
+++ b/source/p_map.cpp
@@ -32,6 +32,7 @@
 #include "d_mod.h"
 #include "doomstat.h"
 #include "e_exdata.h"
+#include "e_player.h"
 #include "e_states.h"
 #include "e_things.h"
 #include "m_argv.h"
@@ -1524,7 +1525,7 @@ static bool P_checkCarryUp(Mobj &thing, fixed_t floorz)
       {
          other->player->viewheight += *orgzit - other->z;
          other->player->deltaviewheight =
-         (VIEWHEIGHT - other->player->viewheight) >> 3;
+         (other->player->pclass->viewheight - other->player->viewheight) >> 3;
       }
       ++orgzit;
    }

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -955,7 +955,7 @@ static void P_ZMovement(Mobj* mo)
    {
       mo->player->viewheight -= mo->zref.floor-mo->z;
       mo->player->deltaviewheight =
-         (VIEWHEIGHT - mo->player->viewheight)>>3;
+         (mo->player->pclass->viewheight - mo->player->viewheight)>>3;
    }
 
    // adjust altitude
@@ -1484,7 +1484,7 @@ void Mobj::Think()
                {
                   fixed_t deltaview;
                   player->viewheight -= onmo->z + onmo->height - z;
-                  deltaview = (VIEWHEIGHT - player->viewheight)>>3;
+                  deltaview = (player->pclass->viewheight - player->viewheight)>>3;
                   if(deltaview > player->deltaviewheight)
                   {
                      player->deltaviewheight = deltaview;
@@ -2186,8 +2186,8 @@ void P_SpawnPlayer(mapthing_t* mthing)
    p->bonuscount    = 0;
    p->extralight    = 0;
    p->fixedcolormap = 0;
-   p->viewheight    = VIEWHEIGHT;
-   p->viewz         = mobj->z + VIEWHEIGHT;
+   p->viewheight    = p->pclass->viewheight;
+   p->viewz         = mobj->z + p->pclass->viewheight;
    p->prevviewz     = p->viewz;
 
    p->momx = p->momy = 0;   // killough 10/98: initialize bobbing to 0.
@@ -3326,7 +3326,7 @@ void P_AdjustFloorClip(Mobj *thing)
       player_t *p = thing->player;
 
       p->viewheight -= oldclip - thing->floorclip;
-      p->deltaviewheight = (VIEWHEIGHT - p->viewheight) / 8;
+      p->deltaviewheight = (p->pclass->viewheight - p->viewheight) / 8;
    }
 }
 

--- a/source/p_mobj.h
+++ b/source/p_mobj.h
@@ -52,7 +52,7 @@ class  BloodSpawner;
 
 // Defines
 
-#define VIEWHEIGHT      (41*FRACUNIT)
+// [XA] VIEWHEIGHT is now a playerclass property
 
 // sf: gravity >>> defaultgravity
 #define DEFAULTGRAVITY  FRACUNIT

--- a/source/p_user.cpp
+++ b/source/p_user.cpp
@@ -196,7 +196,7 @@ void P_CalcHeight(player_t *player)
 
    if(!onground || player->cheats & CF_NOMOMENTUM)
    {
-      player->viewz = player->mo->z + VIEWHEIGHT;
+      player->viewz = player->mo->z + player->pclass->viewheight;
       
       if(player->viewz > player->mo->zref.ceiling - 4 * FRACUNIT)
          player->viewz = player->mo->zref.ceiling - 4 * FRACUNIT;
@@ -220,15 +220,15 @@ void P_CalcHeight(player_t *player)
    {
       player->viewheight += player->deltaviewheight;
       
-      if(player->viewheight > VIEWHEIGHT)
+      if(player->viewheight > player->pclass->viewheight)
       {
-         player->viewheight = VIEWHEIGHT;
+         player->viewheight = player->pclass->viewheight;
          player->deltaviewheight = 0;
       }
 
-      if(player->viewheight < VIEWHEIGHT / 2)
+      if(player->viewheight < player->pclass->viewheight / 2)
       {
-         player->viewheight = VIEWHEIGHT / 2;
+         player->viewheight = player->pclass->viewheight / 2;
          if(player->deltaviewheight <= 0)
             player->deltaviewheight = 1;
       }


### PR DESCRIPTION
This lil' feature allows you to adjust the player's view height via EDF via a new "viewheight" playerclass property.

I haven't touched any of the base EDF, since the original default (41 units, in fixed point) is specified in code, but lemme know if y'all need me to edit that too.