### PR TITLE
Add "noammo" flag to FirePlayerMissile

### DIFF
--- a/source/d_deh.cpp
+++ b/source/d_deh.cpp
@@ -851,6 +851,25 @@ unsigned int *deh_ParseFlagsCombined(const char *strval)
    return dehacked_flags.results;
 }
 
+unsigned int *deh_ParseFlagsCustom(dehflagset_t *flagset, const char *strval)
+{
+   char *buffer;
+   char *bufferptr;
+
+   if(flagset == nullptr)
+      return 0;
+
+   bufferptr = buffer = estrdup(strval);
+
+   flagset->mode = DEHFLAGS_MODE_ALL;
+
+   deh_ParseFlags(flagset, &bufferptr);
+
+   efree(buffer);
+
+   return flagset->results;
+}
+
 #define MOBJFLAGSINDEX  21
 #define MOBJFLAGS2INDEX 22
 #define MOBJTRANSINDEX  24

--- a/source/d_dehtbl.h
+++ b/source/d_dehtbl.h
@@ -92,6 +92,7 @@ dehflags_t   *deh_ParseFlagCombined(const char *name);
 void          deh_ParseFlags(dehflagset_t *dehflags, char **strval);
 unsigned int  deh_ParseFlagsSingle(const char *strval, int mode);
 unsigned int *deh_ParseFlagsCombined(const char *strval);
+unsigned int *deh_ParseFlagsCustom(dehflagset_t *flagset, const char *strval);
 
 // deh queue stuff
 void D_DEHQueueInit(void);

--- a/source/e_args.cpp
+++ b/source/e_args.cpp
@@ -741,6 +741,41 @@ unsigned int *E_ArgAsThingFlags(arglist_t *al, int index)
 }
 
 //
+// Gets the arg value at index i as a flag mask, if such argument  exists,
+// using the specified flagset. The evaluated value will be cached
+// so that it can be returned on subsequent calls. If the arg does not
+// exist, NULL is returned.
+//
+unsigned int E_ArgAsFlags(arglist_t *al, int index, dehflagset_t *flagset)
+{
+   // if the arglist doesn't exist or doesn't hold this many arguments,
+   // return the default value.
+   if(!al || index >= al->numargs)
+      return 0;
+
+   evalcache_t &eval = al->values[index];
+
+   if(eval.type != EVALTYPE_THINGFLAG)
+   {
+      eval.type = EVALTYPE_THINGFLAG;
+
+      // empty string is zero
+      if(*(al->args[index]) != '\0')
+      {
+         unsigned int *flagvals = deh_ParseFlagsCustom(flagset, al->args[index]);
+
+         memcpy(eval.value.flags, flagvals, MAXFLAGFIELDS * sizeof(unsigned int));
+      }
+      else
+         memset(eval.value.flags, 0, MAXFLAGFIELDS * sizeof(unsigned int));
+   }
+
+   // [XA] since arg flags aren't expected to be mega-huge, just return the
+   // first result index rather than make every action function care about this.
+   return eval.value.flags[0];
+}
+
+//
 // Gets the arg value at index i as a sound, if such argument exists.
 // The evaluated value will be cached so that it can be returned on subsequent
 // calls. If the arg does not exist, NULL is returned.

--- a/source/e_args.h
+++ b/source/e_args.h
@@ -118,6 +118,7 @@ int           E_ArgAsStateNumNI(arglist_t *al, int index, const player_t *player
 int           E_ArgAsStateNumG0(arglist_t *al, int index, const Mobj     *mo);
 int           E_ArgAsStateNumG0(arglist_t *al, int index, const player_t *player);
 unsigned int *E_ArgAsThingFlags(arglist_t *al, int index);
+unsigned int  E_ArgAsFlags(arglist_t *al, int index, dehflagset_t *flagset);
 sfxinfo_t    *E_ArgAsSound(arglist_t *al, int index);
 int           E_ArgAsBexptr(arglist_t *al, int index);
 edf_string_t *E_ArgAsEDFString(arglist_t *al, int index);


### PR DESCRIPTION
I ran into a case where I'm wanting to fire multiple projectiles out of a weapon at once but only use a single unit of ammo, so I converted the "homing" arg to a flags field and added a new "noammo" flag. The arg is fully backwards-compatible, but now you can pipe-separate multiple keywords in the same arg; huzzah!

Here's a super-quick test wad: stand back and fire the pistol and observe as it only uses 1 ammo to fire a 4-rocket burst. The rockets also seek enemies too, as a proof-of-concept of flag combination.
[weaponflags.zip](https://github.com/team-eternity/eternity/files/4211490/weaponflags.zip)

This is just one of a few extensions to this function I'm planning on making (we need some projectile shotguns, dangit!), but figured I'd submit this one first since it has the largest "surface area", so to speak.

Probably a good idea to add this to FireCustomBullets at some point, but it's a bit less dire since you can already fire multiple pellets in a single function call, and I don't want to just tack on a "flags" field just yet until I have a chance to flesh out a few things.