### PR TITLE
Fast Missiles!

### DIFF
--- a/base/hexen/things.edf
+++ b/base/hexen/things.edf
@@ -1,0 +1,48 @@
+//
+// EDF for Eternity Engine v3.40.50
+//
+// Thing type definitions for Hexen gamemode.
+//
+
+// NOTE: this is EXTREMELY UNFINISHED.
+// At present, this only serves to pre-populate some
+// de-hardcoded values so we get accurate behavior
+// in the future.
+
+thingtype MageWandSmoke
+{
+  // TODO: everything
+}
+
+thingtype MageWandMissile
+{
+  cflags FASTMISSILE
+
+  // TODO: rest of flags & properties
+
+  trail.type        MageWandSmoke
+  trail.zoffset     -8.0
+  trail.spawnchance 127
+  trail.sparsity    1
+
+  // TODO: states
+}
+
+thingtype CFlameFloor
+{
+  // TODO: everything
+}
+
+thingtype CFlameMissile 
+{
+  cflags FASTMISSILE
+
+  // TODO: rest of flags & properties
+
+  trail.type        CFlameFloor
+  trail.zoffset     -12.0
+  trail.spawnchance 255
+  trail.sparsity    4
+
+  // TODO: states
+}

--- a/source/d_deh.cpp
+++ b/source/d_deh.cpp
@@ -346,6 +346,7 @@ dehflags_t deh_mobjflags[] =
   {"STICKYCARRY",        0x08000000, 3},
   {"SETTARGETONDEATH",   0x10000000, 3},
   {"SLIDEOVERTHINGS",    0x20000000, 3},
+  {"FASTMISSILE",        0x40000000, 3}, // [XA] use Hexen's fast-projectile physics
 
   { NULL,              0 }             // NULL terminator
 };

--- a/source/e_things.cpp
+++ b/source/e_things.cpp
@@ -1733,11 +1733,11 @@ static void E_processItemRespawnAt(mobjinfo_t *mi, const char *name)
 //
 static void E_processTrailType(mobjinfo_t *mi, const char *name)
 {
-   if (*name)
+   if(*name)
    {
       mi->trailthingnum = E_ThingNumForName(name);
 
-      if (mi->trailthingnum < 0)
+      if(mi->trailthingnum < 0)
       {
          E_EDFLoggedWarning(2,
             "Warning: Unknown thingtype '%s' specified as trail.type for '%s'\n",
@@ -3006,19 +3006,19 @@ void E_ProcessThing(int i, cfg_t *thingsec, cfg_t *pcfg, bool def)
    }
 
    // [XA] 02-22-2020: process projectile trail fields
-   if (IS_SET(ITEM_TNG_TRAILTYPE))
+   if(IS_SET(ITEM_TNG_TRAILTYPE))
       E_processTrailType(mobjinfo[i], cfg_getstr(thingsec, ITEM_TNG_TRAILTYPE));
 
-   if (IS_SET(ITEM_TNG_TRAILZOFFSET))
+   if(IS_SET(ITEM_TNG_TRAILZOFFSET))
    {
       tempfloat = cfg_getfloat(thingsec, ITEM_TNG_TRAILZOFFSET);
       mobjinfo[i]->trailzoffset = (int)(tempfloat * FRACUNIT);
    }
 
-   if (IS_SET(ITEM_TNG_TRAILCHANCE))
+   if(IS_SET(ITEM_TNG_TRAILCHANCE))
       mobjinfo[i]->trailchance = cfg_getint(thingsec, ITEM_TNG_TRAILCHANCE);
 
-   if (IS_SET(ITEM_TNG_TRAILSPARSITY))
+   if(IS_SET(ITEM_TNG_TRAILSPARSITY))
       mobjinfo[i]->trailsparsity = cfg_getint(thingsec, ITEM_TNG_TRAILSPARSITY);
 
    // Process DECORATE state block

--- a/source/info.h
+++ b/source/info.h
@@ -422,6 +422,10 @@ struct mobjinfo_t
    int activatesound;   // haleyjd 03/19/11: Hexen activation sound
    int deactivatesound; // haleyjd 03/19/11: Hexen deactivation sound
    int gibhealth;       // haleyjd 09/12/13: health at which actor gibs
+   int trailthingnum;   // [XA] 02/22/2020: projectile trail thing number
+   int trailzoffset;    // [XA] 02/22/2020: projectile trail z offset (fixed point)
+   int trailchance;     // [XA] 02/22/2020: projectile trail spawn chance (out of 255)
+   int trailsparsity;   // [XA] 02/22/2020: projectile trail sparsity
 
    e_pickupfx_t *pickupfx;
 

--- a/source/m_random.h
+++ b/source/m_random.h
@@ -239,6 +239,7 @@ typedef enum {
   pr_hereticartiteleport, // A_ArtiTele
   pr_puffblood,   // P_shootThing draw blood when Heretic-like puff is defined
   pr_nailbombshoot,  // A_Nailbomb random damage
+  pr_fasttrailchance,         // [XA] 02/22/2020: Fast projectile trail spawn-chance
 
   NUMPRCLASS                  // MUST be last item in list
 } pr_class_t;

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -1636,7 +1636,7 @@ void Mobj::ThinkFast()
    Mobj *mo;
 
    // backup previous position for interpolation
-   if (!player || player->mo != this)
+   if(!player || player->mo != this)
       backupPosition();
 
    // Handle movement

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -1389,6 +1389,15 @@ void Mobj::Think()
       return;
    }
 
+   // [XA] 02/22/20: use Hexen's fastprojectile think function
+   // exclusively if the flag's set, for maximum compatibility.
+   // also, today's date is amazing.
+   if(flags4 & MF4_FASTMISSILE)
+   {
+      ThinkFast();
+      return;
+   }
+
    int oldwaterstate, waterstate = 0;
    fixed_t lz;
 
@@ -1605,6 +1614,111 @@ void Mobj::Think()
    // FIXME: may be insufficient
    if(!removed)
       P_checkMobjProjections(*this);
+}
+
+//
+// Mobj::ThinkFast
+//
+// [XA] This is pretty much a direct port of Hexen's fast-projectile
+// code, warts and all. Since this is a completely different code
+// path from normal Think, there's a lot of features that aren't
+// supported on fast projectiles... yet? Either way, this is
+// experimental for now. Swim at your own risk, etc.
+//
+void Mobj::ThinkFast()
+{
+   int i;
+   fixed_t xfrac;
+   fixed_t yfrac;
+   fixed_t zfrac;
+   fixed_t z;
+   bool changexy;
+   Mobj *mo;
+
+   // backup previous position for interpolation
+   if (!player || player->mo != this)
+      backupPosition();
+
+   // Handle movement
+   if(this->momx || this->momy ||
+      (this->z != this->zref.floor) || this->momz)
+   {
+      xfrac = this->momx>>3;
+      yfrac = this->momy>>3;
+      zfrac = this->momz>>3;
+      changexy = xfrac || yfrac;
+
+      for(i = 0; i < 8; i++)
+      {
+         if(changexy)
+         {
+            if(!P_TryMove(this, this->x+xfrac, this->y+yfrac, false))
+            {
+               // Blocked move
+               P_ExplodeMissile(this, nullptr);
+               return;
+            }
+         }
+
+         this->z += zfrac;
+         if(this->z <= this->zref.floor)
+         {
+            // Hit the floor
+            this->z = this->zref.floor;
+            E_HitFloor(this);
+            P_ExplodeMissile(this, nullptr);
+            return;
+         }
+
+         if(this->z+this->height > this->zref.ceiling)
+         {
+            // Hit the ceiling
+            this->z = this->zref.ceiling-this->height;
+            P_ExplodeMissile(this, nullptr);
+            return;
+         }
+
+         if(changexy && this->info->trailthingnum >= 0)
+         {
+            // [XA] spawn a trail once every <trailsparsity>
+            // movement steps. This is a generalized form of
+            // Hexen's CFlame behavior, where it only spawned
+            // every 4th movement step. Yeah, the way this
+            // is coded means that values below 1 are the
+            // same as 1. Meh, sue me. :P
+            if(--this->counters[0] <= 0)
+            {
+               this->counters[0] = this->info->trailsparsity;
+
+               // [XA] random chance to spawn. A generalized
+               // version of Hexen's MWand's 50% spawn chance.
+               if(P_Random(pr_fasttrailchance) <= this->info->trailchance)
+               {
+                  z = this->z + this->info->trailzoffset;
+                  if(z < this->zref.floor)
+                     z = this->zref.floor;
+                  else if(z > this->zref.ceiling)
+                     z = this->zref.ceiling;
+
+                  // [XA] as a heads-up, this angle adjustment was
+                  // only done for the CFlame trail, not the MWand
+                  // one. Hopefully doing it for both doesn't
+                  // break anything... 9_6
+                  mo = P_SpawnMobj(this->x, this->y, z, this->info->trailthingnum);
+                  if(mo)
+                     mo->angle = this->angle;
+               }
+            }
+         }
+      }
+   }
+
+   // Advance the state
+   if(tics != -1) // you can cycle through multiple states in a tic
+   {
+      if(!--tics)
+         P_SetMobjState(this, state->nextstate);
+   }
 }
 
 //

--- a/source/p_mobj.h
+++ b/source/p_mobj.h
@@ -214,6 +214,7 @@ protected:
 
    // Methods
    void Think() override;
+   void ThinkFast();
 
    bool shouldApplyTorque();
 
@@ -700,7 +701,8 @@ enum mobjflags4_e : unsigned int
    MF4_LOWAIMPRIO         = 0x04000000, // can't be autoaimed.
    MF4_STICKYCARRY        = 0x08000000, // can carry other things on top of it.
    MF4_SETTARGETONDEATH   = 0x10000000, // target is updated even when one-shot
-   MF4_SLIDEOVERTHINGS    = 0x20000000  // thing will keep sliding when on top of things
+   MF4_SLIDEOVERTHINGS    = 0x20000000, // thing will keep sliding when on top of things
+   MF4_FASTMISSILE        = 0x40000000  // [XA] use Hexen's fast-projectile physics
 };
 
 // killough 9/15/98: Same, but internal flags, not intended for .deh


### PR DESCRIPTION
Adds Heretic/Hexen fastprojectile support. Basically a direct port of Hexen's code, with the trail-spawning behavior generalized.

A quick summary of the new stuff:
- A new `FASTMISSILE` flag, which enables the new movement behavior.
- Four new properties for controlling the spawned trail:
  - `trail.type`: Actor type to spawn.
  - `trail.zoffset`: Z-offset of the spawned actor.
  - `trail.spawnchance`: Chance (out of 255, for consistency) for the actor to spawn.
  - `trail.sparsity`: How sparse the trail is. 1 is max density, 2 is a bit more spread out, 3 is further, etc.*

[Tech explanation behind `trail.sparsity`: In a single tic, Fastmissiles actually do 8 movement steps (each one for 1/8 of its Speed value), and `sparsity` tells it to spawn a trail every `nth` movement step. This is how Hexen did it -- the mage wand projectile spawns a trail actor every movement step (`sparsity=1`), while the Cleric frame does it every 4th movement step (`sparsity=4`). I made the implementation match 'cause I didn't want to risk fudging up the exact values.]

There's liable to be a few "holes" in the implementation that need patching to work with certain Eternity features (portals??), but here's a stable base to build upon at least.

I've also included some extremely-barebones EDFs for the two Hexen actors that use this code, basically just to pre-fill all the `trail.` properties so their behavior is accurate. Haven't done the Heretic Blaster projectile yet, 'cause I figure adding the powered blaster in full is worth is own PR. This unblocks that, BTW. ;)

Finally, I'd love to implement the `trail` properties at some point for normal projectiles -- I've seen folks use fastprojectiles in GZD _just_ for the trail spawning (myself included), which is sort of an antipattern when you think of it. Might be worth including a disclaimer in the docs to not use these in non-fastmissiles in a mod just yet, otherwise a future EE version might just yank out the rug.

Words.