### PR TITLE
A_SpawnEx action function

### DIFF
--- a/source/a_general.cpp
+++ b/source/a_general.cpp
@@ -458,10 +458,10 @@ void A_SpawnEx(actionargs_t *actionargs)
       P_RotatePoint(xvel, yvel, angle);
 
    mo = P_SpawnMobj(xpos, ypos, zpos, thingtype);
-   if (mo == nullptr)
+   if(mo == nullptr)
       return;
 
-   if ((flags & SPAWNEX_CHECKPOSITION) && !P_CheckPositionExt(mo, mo->x, mo->y, mo->z))
+   if((flags & SPAWNEX_CHECKPOSITION) && !P_CheckPositionExt(mo, mo->x, mo->y, mo->z))
       mo->remove();
    else {
       mo->angle = angle;

--- a/source/d_dehtbl.cpp
+++ b/source/d_dehtbl.cpp
@@ -1329,6 +1329,7 @@ void A_Nailbomb(actionargs_t *);
 // haleyjd: start new eternity action functions
 void A_SpawnAbove(actionargs_t *);
 void A_SpawnGlitter(actionargs_t *);
+void A_SpawnEx(actionargs_t *);
 void A_SetFlags(actionargs_t *);
 void A_UnSetFlags(actionargs_t *);
 void A_BetaSkullAttack(actionargs_t *);
@@ -1679,6 +1680,7 @@ deh_bexptr deh_bexptrs[] =
    // haleyjd: start new eternity codeptrs
    POINTER(SpawnAbove),
    POINTER(SpawnGlitter),
+   POINTER(SpawnEx),
    POINTER(StartScript),
    POINTER(StartScriptNamed),
    POINTER(PlayerStartScript),

--- a/source/e_args.cpp
+++ b/source/e_args.cpp
@@ -37,6 +37,7 @@
 #include "info.h"
 #include "m_utils.h"
 #include "p_mobj.h"
+#include "p_maputl.h"
 
 // haleyjd 05/21/10: a static empty string, to avoid allocating tons of memory 
 // for single-byte strings.
@@ -241,6 +242,32 @@ double E_ArgAsDouble(arglist_t *al, int index, double defvalue)
    }
 
    return eval.value.d;
+}
+
+//
+// Gets the arg value at index i as an angle_t, if such argument exists.
+// The evaluated value will be cached so that it can be returned on
+// subsequent calls. If the argument does not exist, the value passed in
+// the "defvalue" argument will be returned.
+//
+angle_t E_ArgAsAngle(arglist_t *al, int index, angle_t defvalue)
+{
+   // if the arglist doesn't exist or doesn't hold this many arguments,
+   // return the default value.
+   if(!al || index >= al->numargs)
+      return defvalue;
+
+   evalcache_t &eval = al->values[index];
+
+   // if the value is cached, return the cached value
+   if(eval.type != EVALTYPE_ANGLE)
+   {
+      // calculate the value and cache it
+      eval.type    = EVALTYPE_ANGLE;
+      eval.value.a = P_DoubleToAngle(strtod(al->args[index], nullptr));
+   }
+
+   return eval.value.a;
 }
 
 //

--- a/source/e_args.h
+++ b/source/e_args.h
@@ -33,6 +33,7 @@
 // needed for MAXFLAGFIELDS:
 #include "d_dehtbl.h"
 #include "m_fixed.h"
+#include "tables.h"
 
 struct edf_string_t;
 struct emod_t;
@@ -56,6 +57,7 @@ typedef enum
    EVALTYPE_INT,       // evaluated to an integer
    EVALTYPE_FIXED,     // evaluated to a fixed_t
    EVALTYPE_DOUBLE,    // evaluated to a double
+   EVALTYPE_ANGLE,     // evaluated to an angle_t
    EVALTYPE_THINGNUM,  // evaluated to a thing number
    EVALTYPE_STATENUM,  // evaluated to a state number
    EVALTYPE_THINGFLAG, // evaluated to a thing flag bitmask
@@ -75,6 +77,7 @@ typedef struct evalcache_s
       int           i;
       fixed_t       x;
       double        d;
+      angle_t       a;
       sfxinfo_t    *s;
       edf_string_t *estr;
       emod_t       *mod;
@@ -107,6 +110,7 @@ const char   *E_ArgAsString(const arglist_t *al, int index, const char *defvalue
 int           E_ArgAsInt(arglist_t *al, int index, int defvalue);
 fixed_t       E_ArgAsFixed(arglist_t *al, int index, fixed_t defvalue);
 double        E_ArgAsDouble(arglist_t *al, int index, double defvalue);
+angle_t       E_ArgAsAngle(arglist_t *al, int index, angle_t defvalue);
 int           E_ArgAsThingNum(arglist_t *al, int index);
 int           E_ArgAsThingNumG0(arglist_t *al, int index);
 state_t      *E_ArgAsStateLabel(const Mobj *mo,         const arglist_t *al, int index);

--- a/source/m_random.h
+++ b/source/m_random.h
@@ -240,6 +240,8 @@ typedef enum {
   pr_puffblood,   // P_shootThing draw blood when Heretic-like puff is defined
   pr_nailbombshoot,  // A_Nailbomb random damage
 
+  pr_spawnexchance,           // [XA] 02/28/2020: A_SpawnEx spawnchance
+
   NUMPRCLASS                  // MUST be last item in list
 } pr_class_t;
 

--- a/source/p_maputl.cpp
+++ b/source/p_maputl.cpp
@@ -913,6 +913,40 @@ angle_t P_PointToAngle(fixed_t xo, fixed_t yo, fixed_t x, fixed_t y)
    return 0;
 }
 
+//
+// [XA] 02/29/20:
+//
+// double --> angle conversion, mainly for EDF usage.
+// presumes 'a' is in degrees, like the rest of
+// the various to-angle conversion functions. Negative
+// angles are supported.
+//
+angle_t P_DoubleToAngle(double a)
+{
+   // normalize the angle to [0, 360)
+   a = fmod(a, 360.0);
+   if (a < 0)
+      a += 360.0;
+
+   // convert dat shit
+   return FixedToAngle(M_DoubleToFixed(a));
+}
+
+//
+// [XA] 02/29/20:
+//
+// Rotates a point by the specified angle. 'Nuff said.
+//
+void P_RotatePoint(fixed_t & x, fixed_t & y, const angle_t angle)
+{
+   fixed_t tmp;
+   fixed_t sin = finesine[angle >> ANGLETOFINESHIFT];
+   fixed_t cos = finecosine[angle >> ANGLETOFINESHIFT];
+   tmp = FixedMul(x, cos) - FixedMul(y, sin);
+   y = FixedMul(x, sin) + FixedMul(y, cos);
+   x = tmp;
+}
+
 //----------------------------------------------------------------------------
 //
 // $Log: p_maputl.c,v $

--- a/source/p_maputl.cpp
+++ b/source/p_maputl.cpp
@@ -925,7 +925,7 @@ angle_t P_DoubleToAngle(double a)
 {
    // normalize the angle to [0, 360)
    a = fmod(a, 360.0);
-   if (a < 0)
+   if(a < 0)
       a += 360.0;
 
    // convert dat shit

--- a/source/p_maputl.cpp
+++ b/source/p_maputl.cpp
@@ -937,7 +937,7 @@ angle_t P_DoubleToAngle(double a)
 //
 // Rotates a point by the specified angle. 'Nuff said.
 //
-void P_RotatePoint(fixed_t & x, fixed_t & y, const angle_t angle)
+void P_RotatePoint(fixed_t &x, fixed_t &y, const angle_t angle)
 {
    fixed_t tmp;
    fixed_t sin = finesine[angle >> ANGLETOFINESHIFT];

--- a/source/p_maputl.h
+++ b/source/p_maputl.h
@@ -139,7 +139,7 @@ bool P_PathTraverse(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2,
 angle_t P_PointToAngle(fixed_t xo, fixed_t yo, fixed_t x, fixed_t y);
 angle_t P_DoubleToAngle(double a);
 
-void P_RotatePoint(fixed_t & x, fixed_t & y, const angle_t angle);
+void P_RotatePoint(fixed_t &x, fixed_t &y, const angle_t angle);
 
 bool P_ShootThing(const intercept_t *in,
                   Mobj *shooter,

--- a/source/p_maputl.h
+++ b/source/p_maputl.h
@@ -137,6 +137,9 @@ bool P_PathTraverse(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2,
                     int flags, traverser_t trav, void *context = nullptr);
 
 angle_t P_PointToAngle(fixed_t xo, fixed_t yo, fixed_t x, fixed_t y);
+angle_t P_DoubleToAngle(double a);
+
+void P_RotatePoint(fixed_t & x, fixed_t & y, const angle_t angle);
 
 bool P_ShootThing(const intercept_t *in,
                   Mobj *shooter,


### PR DESCRIPTION
Adds a flexible `A_SpawnEx` action function, for all your spawning needs.

Parameters:
- **type**: The thing type to spawn.
- **flags**: Any of the following (pipe-separated), or "normal"/0 if you don't want to set any.
  - **absoluteangle**: treat *angle* field as an absolute angle, not relative to calling actor's angle
  - **absolutevelocity**: treat *velocity* fields as absolute x/y velocities, not relative to *angle*
  - **absoluteposition**:  treat *offset* fields as absolute x/y positions, not relative to calling actor's position
  - **checkposition**: check to see if the actor fits (i.e. doesn't spawn inside geometry or a solid actor); if not, the actor is not spawned. Highly useful if you wish to spawn a solid object.
- **x-offset**: forwards/backwards offset
- **y-offset**: right/left offset
- **z-offset**: up/down offset
- **x-velocity**: forwards/backwards velocity
- **y-velocity**: right/left velocity
- **z-velocity**: up/down velocity
- **angle**: angle to use as a reference for x/y/z offsets and velocities. Is relative to calling actor's angle unless `absoluteposition` is set.
- **spawnchance**: chance (out of 255) for the object to spawn; default is 255.

The argument order is a bit different from GZD's (`flags` is early since it's so damn important), and the `checkposition` flag simply does exactly what you tell it to, rather than follow GZD's crazy rules.

There's a handful of other flags that I'll probably add in later (e.g. something akin to gzd's SXF_TRANSFERPOINTERS); I just didn't want to overcomplicate the initial submission.