### PR TITLE
Add "damagemod" thing property

### DIFF
--- a/source/e_things.cpp
+++ b/source/e_things.cpp
@@ -134,6 +134,7 @@ int UnknownThingType;
 
 // Damage Properties
 #define ITEM_TNG_DAMAGE       "damage"
+#define ITEM_TNG_DAMAGEMOD    "damagemod"
 #define ITEM_TNG_DMGSPECIAL   "dmgspecial"
 #define ITEM_TNG_DAMAGEFACTOR "damagefactor"
 #define ITEM_TNG_TOPDAMAGE    "topdamage"
@@ -554,6 +555,7 @@ static int E_TranMapCB(cfg_t *, cfg_opt_t *, const char *, void *);
    CFG_INT(ITEM_TNG_RESPCHANCE,      4,             CFGF_NONE), \
    CFG_INT(ITEM_TNG_AIMSHIFT,        -1,            CFGF_NONE), \
    CFG_INT(ITEM_TNG_DAMAGE,          0,             CFGF_NONE), \
+   CFG_INT(ITEM_TNG_DAMAGEMOD,       8,             CFGF_NONE), \
    CFG_STR(ITEM_TNG_DMGSPECIAL,      "NONE",        CFGF_NONE), \
    CFG_INT(ITEM_TNG_TOPDAMAGE,       0,             CFGF_NONE), \
    CFG_INT(ITEM_TNG_TOPDMGMASK,      0,             CFGF_NONE), \
@@ -2605,6 +2607,10 @@ void E_ProcessThing(int i, cfg_t *thingsec, cfg_t *pcfg, bool def)
    // process damage
    if(IS_SET(ITEM_TNG_DAMAGE))
       mobjinfo[i]->damage = cfg_getint(thingsec, ITEM_TNG_DAMAGE);
+
+   // [XA] 02/29/20: process damagemod
+   if (IS_SET(ITEM_TNG_DAMAGEMOD))
+      mobjinfo[i]->damagemod = cfg_getint(thingsec, ITEM_TNG_DAMAGEMOD);
 
    // 09/22/06: process topdamage 
    if(IS_SET(ITEM_TNG_TOPDAMAGE))

--- a/source/e_things.cpp
+++ b/source/e_things.cpp
@@ -2609,7 +2609,7 @@ void E_ProcessThing(int i, cfg_t *thingsec, cfg_t *pcfg, bool def)
       mobjinfo[i]->damage = cfg_getint(thingsec, ITEM_TNG_DAMAGE);
 
    // [XA] 02/29/20: process damagemod
-   if (IS_SET(ITEM_TNG_DAMAGEMOD))
+   if(IS_SET(ITEM_TNG_DAMAGEMOD))
       mobjinfo[i]->damagemod = cfg_getint(thingsec, ITEM_TNG_DAMAGEMOD);
 
    // 09/22/06: process topdamage 

--- a/source/info.h
+++ b/source/info.h
@@ -388,6 +388,7 @@ struct mobjinfo_t
                         //  seem to retreat when shot because they have
                         //  very little mass and are moved by impact
    int damage;          // If this is a missile, how much does it hurt?
+   int damagemod;       // [XA] damage modulus (i.e. the 8 in '1d8')
    int activesound;     // What sound it makes wandering around, once
                         //  in a while.  Chance is 3/256 it will.
    unsigned int flags;  // Bit masks for lots of things.  See p_mobj.h

--- a/source/p_map.cpp
+++ b/source/p_map.cpp
@@ -1020,7 +1020,7 @@ ItemCheckResult P_CheckThingCommon(Mobj *thing)
 
       // damage / explode
       
-      damage = ((P_Random(pr_damage)%8)+1)*clip.thing->damage;
+      damage = ((P_Random(pr_damage)%clip.thing->info->damagemod)+1)*clip.thing->damage;
       
       // haleyjd: in Heretic & Hexen, zero-damage missiles don't make this call
       if(damage || !(clip.thing->flags4 & MF4_NOZERODAMAGE))


### PR DESCRIPTION
A small one this time -- For the classic projectile damage formula `damage * (P_Random(blah) % 8 + 1)`, the `damagemod` property lets you customize that `8`. ;)

Justification: I wanted a projectile to do the same damage as a bullet (`5d3`), and the various bullet attack functions let you customize the modulus, so here we are.