### PR TITLE
+TARGETSHOOTER pufftype flag

### DIFF
--- a/source/a_doom.cpp
+++ b/source/a_doom.cpp
@@ -490,7 +490,7 @@ void A_Tracer(actionargs_t *actionargs)
       return;
 
    // spawn a puff of smoke behind the rocket
-   P_SpawnPuff(actor->x, actor->y, actor->z, 0, 3, false);
+   P_SpawnPuff(actor->x, actor->y, actor->z, 0, 3, false, actor->target);
    
    th = P_SpawnMobj(actor->x - actor->momx,
                     actor->y - actor->momy,

--- a/source/cam_shoot.cpp
+++ b/source/cam_shoot.cpp
@@ -394,7 +394,7 @@ bool ShootContext::shootTraverse(const intercept_t *in, void *data,
          return false;
 
       P_SpawnPuff(x, y, z, P_PointToAngle(0, 0, li->dx, li->dy) - ANG90,
-         updown, true, E_PuffForIndex(context.params.puffidx));
+         updown, true, context.params.thing, E_PuffForIndex(context.params.puffidx));
 
       return false;
    }

--- a/source/e_puff.cpp
+++ b/source/e_puff.cpp
@@ -55,10 +55,11 @@
 #define ITEM_PUFF_PUNCHHACK       "punchhack"
 #define ITEM_PUFF_PARTICLES       "particles"
 
-#define ITEM_PUFF_ALWAYSPUFF  "ALWAYSPUFF"
-#define ITEM_PUFF_BLOODLESS   "BLOODLESS"
-#define ITEM_PUFF_LOCALTHRUST "LOCALTHRUST"
-#define ITEM_PUFF_RANDOMTICS  "RANDOMTICS"
+#define ITEM_PUFF_ALWAYSPUFF      "ALWAYSPUFF"
+#define ITEM_PUFF_BLOODLESS       "BLOODLESS"
+#define ITEM_PUFF_LOCALTHRUST     "LOCALTHRUST"
+#define ITEM_PUFF_RANDOMTICS      "RANDOMTICS"
+#define ITEM_PUFF_TARGETSHOOTER   "TARGETSHOOTER"
 
 // Interned metatable keys
 MetaKeyIndex keyPuffThingType      (ITEM_PUFF_THINGTYPE      );
@@ -74,6 +75,7 @@ MetaKeyIndex keyPuffAlwaysPuff     (ITEM_PUFF_ALWAYSPUFF     );
 MetaKeyIndex keyPuffBloodless      (ITEM_PUFF_BLOODLESS      );
 MetaKeyIndex keyPuffLocalThrust    (ITEM_PUFF_LOCALTHRUST    );
 MetaKeyIndex keyPuffRandomTics     (ITEM_PUFF_RANDOMTICS     );
+MetaKeyIndex keyPuffTargetShooter  (ITEM_PUFF_TARGETSHOOTER  );
 
 #define PUFF_CONFIGS \
    CFG_STR(ITEM_PUFF_THINGTYPE,       "",                 CFGF_NONE),       \
@@ -89,6 +91,7 @@ MetaKeyIndex keyPuffRandomTics     (ITEM_PUFF_RANDOMTICS     );
    CFG_FLAG(ITEM_PUFF_BLOODLESS,      0,                  CFGF_SIGNPREFIX), \
    CFG_FLAG(ITEM_PUFF_LOCALTHRUST,    0,                  CFGF_SIGNPREFIX), \
    CFG_FLAG(ITEM_PUFF_RANDOMTICS,     0,                  CFGF_SIGNPREFIX), \
+   CFG_FLAG(ITEM_PUFF_TARGETSHOOTER,  0,                  CFGF_SIGNPREFIX), \
    CFG_END()
 
 //

--- a/source/e_puff.h
+++ b/source/e_puff.h
@@ -50,6 +50,7 @@ extern MetaKeyIndex keyPuffAlwaysPuff;
 extern MetaKeyIndex keyPuffBloodless;
 extern MetaKeyIndex keyPuffLocalThrust;
 extern MetaKeyIndex keyPuffRandomTics;
+extern MetaKeyIndex keyPuffTargetShooter;
 
 extern cfg_opt_t edf_puff_opts[];
 extern cfg_opt_t edf_puff_delta_opts[];

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -2554,8 +2554,8 @@ spawnit:
 // P_SpawnPuff
 //
 Mobj *P_SpawnPuff(fixed_t x, fixed_t y, fixed_t z, angle_t dir,
-                  int updown, bool ptcl, const MetaTable *pufftype,
-                  const Mobj *hitmobj)
+                  int updown, bool ptcl, Mobj *shooter,
+                  const MetaTable *pufftype, const Mobj *hitmobj)
 {
    if(!pufftype)
    {
@@ -2626,6 +2626,16 @@ Mobj *P_SpawnPuff(fixed_t x, fixed_t y, fixed_t z, angle_t dir,
             P_SetMobjState(th, snum);
             punchhack = true;
          }
+      }
+
+      // [XA] 03/02/20: new flag that sets target to the shooter.
+      // This is useful for doing things like setting A_DetonateEx's
+      // hurt_self field on a puff, and other projectile-esque
+      // behaviors that rely on a valid 'target' field. Basically
+      // GZD's "PUFFGETSOWNER" flag but with a less crappy name. :P
+      if(pufftype->getInt(keyPuffTargetShooter, 0))
+      {
+         th->target = shooter;
       }
    }
 

--- a/source/p_mobj.h
+++ b/source/p_mobj.h
@@ -425,7 +425,7 @@ Mobj *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type);
 bool  P_SetMobjState(Mobj *mobj, statenum_t state);
 void  P_MobjThinker(Mobj *mobj);
 Mobj *P_SpawnPuff(fixed_t x, fixed_t y, fixed_t z, angle_t dir, int updown,
-                  bool ptcl, const MetaTable *pufftype = nullptr,
+                  bool ptcl, Mobj *shooter, const MetaTable *pufftype = nullptr,
                   const Mobj *hitmobj = nullptr);
 void  P_SpawnUnknownThings();
 Mobj *P_SpawnMapThing(mapthing_t *mt);

--- a/source/p_trace.cpp
+++ b/source/p_trace.cpp
@@ -275,7 +275,7 @@ bool P_ShootThing(const intercept_t *in,
    if(th->flags & MF_NOBLOOD ||
       th->flags2 & (MF2_INVULNERABLE | MF2_DORMANT))
    {
-      puffmobj = P_SpawnPuff(x, y, z, puffangle, 2, true, pufftype, th);
+      puffmobj = P_SpawnPuff(x, y, z, puffangle, 2, true, shooter, pufftype, th);
    }
    else
    {
@@ -284,7 +284,7 @@ bool P_ShootThing(const intercept_t *in,
       bool showpuff = false;
       if(pufftype && pufftype->getInt(keyPuffAlwaysPuff, 0))
       {
-         puffmobj = P_SpawnPuff(x, y, z, puffangle, 2, true, pufftype, th);
+         puffmobj = P_SpawnPuff(x, y, z, puffangle, 2, true, shooter, pufftype, th);
          showpuff = true;
       }
 
@@ -389,7 +389,7 @@ static bool PTR_ShootTraverseVanilla(intercept_t *in, void *context)
 
       // Spawn bullet puffs.
       P_SpawnPuff(x, y, z, P_PointToAngle(0, 0, li->dx, li->dy) - ANG90, 2, true,
-                  E_PuffForIndex(puffidx));
+                  trace.thing, E_PuffForIndex(puffidx));
 
       // don't go any further
       return false;
@@ -611,7 +611,7 @@ static bool PTR_ShootTraverse(intercept_t *in, void *context)
 
       // Spawn bullet puffs.
       P_SpawnPuff(x, y, z, P_PointToAngle(0, 0, li->dx, li->dy) - ANG90,
-                  updown, true, E_PuffForIndex(puffidx));
+                  updown, true, trace.thing, E_PuffForIndex(puffidx));
       
       // don't go any further     
       return false;


### PR DESCRIPTION
Another quick feature: a new pufftype flag, +TARGETSHOOTER: if set, the puff's target will be set to the Mobj that shot it. 'Nuff said.

The reason for this one is that there's a lot of stuff that's designed for use on projectiles -- A_DetonateEx's "hurt_shooter" property, for instance -- that relies on the `target` field being set to the mobj that fired it. Puffs don't do this, so said features mysteriously won't work as expected... until now. ;)

I whipped up a quick demo wad that shows this in action:
[boompistol.zip](https://github.com/team-eternity/eternity/files/4279371/boompistol.zip)

The gist: your pistol shoots explosive bullets. Primary fire is safe -- it's got the new +TARGETSHOOTER flag and A_DetonateEx's "hurt_shooter" set to zero. The secondary fire, however, uses the same mobj but neglects to add +TARGETSHOOTER, so it'll kill the hell out of you if you shoot a wall with it. :P