### PR TITLE
Add missileheight and bulletzoffset thing properties

### DIFF
--- a/source/a_doom.cpp
+++ b/source/a_doom.cpp
@@ -207,7 +207,7 @@ void A_TroopAttack(actionargs_t *actionargs)
    {
       // launch a missile
       P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_TROOPSHOT),
-                     actor->z + actor->info->missilezoffset);
+                     actor->z + actor->info->missileheight);
    }
 }
 
@@ -279,7 +279,7 @@ void A_HeadAttack(actionargs_t *actionargs)
    {
       // launch a missile
       P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_HEADSHOT),
-                     actor->z + actor->info->missilezoffset);
+                     actor->z + actor->info->missileheight);
    }
 }
 
@@ -306,7 +306,7 @@ void A_BruisAttack(actionargs_t *actionargs)
    {
       // launch a missile
       P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_BRUISERSHOT),
-                     actor->z + actor->info->missilezoffset);
+                     actor->z + actor->info->missileheight);
    }
 }
 
@@ -362,7 +362,7 @@ void A_BspiAttack(actionargs_t *actionargs)
    
    // launch a missile
    P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_ARACHPLAZ), 
-                  actor->z + actor->info->missilezoffset);
+                  actor->z + actor->info->missileheight);
 }
 
 //
@@ -419,7 +419,7 @@ void A_CyberAttack(actionargs_t *actionargs)
    A_FaceTarget(actionargs);
    P_SpawnMissile(actor, actor->target, 
                   E_SafeThingType(MT_ROCKET),
-                  actor->z + actor->info->missilezoffset);
+                  actor->z + actor->info->missileheight);
 }
 
 //=============================================================================
@@ -443,7 +443,7 @@ void A_SkelMissile(actionargs_t *actionargs)
    A_FaceTarget(actionargs);
    actor->z += 16*FRACUNIT;      // so missile spawns higher
    mo = P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_TRACER),
-                       actor->z + actor->info->missilezoffset);
+                       actor->z + actor->info->missileheight);
    actor->z -= 16*FRACUNIT;      // back to normal
    
    mo->x += mo->momx;
@@ -881,7 +881,7 @@ void A_FatAttack1(actionargs_t *actionargs)
    Mobj   *actor = actionargs->actor;
    Mobj   *mo;
    int     an;
-   fixed_t z = actor->z + actor->info->missilezoffset;
+   fixed_t z = actor->z + actor->info->missileheight;
    int FatShotType = E_SafeThingType(MT_FATSHOT);
 
    // haleyjd: no crashing
@@ -912,7 +912,7 @@ void A_FatAttack2(actionargs_t *actionargs)
    Mobj   *actor = actionargs->actor;
    Mobj   *mo;
    int     an;
-   fixed_t z = actor->z + actor->info->missilezoffset;
+   fixed_t z = actor->z + actor->info->missileheight;
    int     FatShotType = E_SafeThingType(MT_FATSHOT);
 
    // haleyjd: no crashing
@@ -942,7 +942,7 @@ void A_FatAttack3(actionargs_t *actionargs)
    Mobj   *actor = actionargs->actor;
    Mobj   *mo;
    int     an;
-   fixed_t z = actor->z + actor->info->missilezoffset;
+   fixed_t z = actor->z + actor->info->missileheight;
    int     FatShotType = E_SafeThingType(MT_FATSHOT);
 
    // haleyjd: no crashing
@@ -1475,7 +1475,7 @@ void A_BrainSpit(actionargs_t *actionargs)
    targ = braintargets.wrapIterator();
 
    // spawn brain missile
-   newmobj = P_SpawnMissile(mo, targ, SpawnShotType, mo->z + mo->info->missilezoffset);
+   newmobj = P_SpawnMissile(mo, targ, SpawnShotType, mo->z + mo->info->missileheight);
    P_SetTarget<Mobj>(&newmobj->target, targ);
    newmobj->reactiontime = (int16_t)(((targ->y-mo->y)/newmobj->momy)/newmobj->state->tics);
 

--- a/source/a_doom.cpp
+++ b/source/a_doom.cpp
@@ -207,7 +207,7 @@ void A_TroopAttack(actionargs_t *actionargs)
    {
       // launch a missile
       P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_TROOPSHOT),
-                     actor->z + DEFAULTMISSILEZ);
+                     actor->z + actor->info->missilezoffset);
    }
 }
 
@@ -279,7 +279,7 @@ void A_HeadAttack(actionargs_t *actionargs)
    {
       // launch a missile
       P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_HEADSHOT),
-                     actor->z + DEFAULTMISSILEZ);
+                     actor->z + actor->info->missilezoffset);
    }
 }
 
@@ -306,7 +306,7 @@ void A_BruisAttack(actionargs_t *actionargs)
    {
       // launch a missile
       P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_BRUISERSHOT),
-                     actor->z + DEFAULTMISSILEZ);  
+                     actor->z + actor->info->missilezoffset);
    }
 }
 
@@ -362,7 +362,7 @@ void A_BspiAttack(actionargs_t *actionargs)
    
    // launch a missile
    P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_ARACHPLAZ), 
-                  actor->z + DEFAULTMISSILEZ);
+                  actor->z + actor->info->missilezoffset);
 }
 
 //
@@ -419,7 +419,7 @@ void A_CyberAttack(actionargs_t *actionargs)
    A_FaceTarget(actionargs);
    P_SpawnMissile(actor, actor->target, 
                   E_SafeThingType(MT_ROCKET),
-                  actor->z + DEFAULTMISSILEZ);   
+                  actor->z + actor->info->missilezoffset);
 }
 
 //=============================================================================
@@ -443,7 +443,7 @@ void A_SkelMissile(actionargs_t *actionargs)
    A_FaceTarget(actionargs);
    actor->z += 16*FRACUNIT;      // so missile spawns higher
    mo = P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_TRACER),
-                       actor->z + DEFAULTMISSILEZ);
+                       actor->z + actor->info->missilezoffset);
    actor->z -= 16*FRACUNIT;      // back to normal
    
    mo->x += mo->momx;
@@ -881,7 +881,7 @@ void A_FatAttack1(actionargs_t *actionargs)
    Mobj   *actor = actionargs->actor;
    Mobj   *mo;
    int     an;
-   fixed_t z = actor->z + DEFAULTMISSILEZ;
+   fixed_t z = actor->z + actor->info->missilezoffset;
    int FatShotType = E_SafeThingType(MT_FATSHOT);
 
    // haleyjd: no crashing
@@ -912,7 +912,7 @@ void A_FatAttack2(actionargs_t *actionargs)
    Mobj   *actor = actionargs->actor;
    Mobj   *mo;
    int     an;
-   fixed_t z = actor->z + DEFAULTMISSILEZ;
+   fixed_t z = actor->z + actor->info->missilezoffset;
    int     FatShotType = E_SafeThingType(MT_FATSHOT);
 
    // haleyjd: no crashing
@@ -942,7 +942,7 @@ void A_FatAttack3(actionargs_t *actionargs)
    Mobj   *actor = actionargs->actor;
    Mobj   *mo;
    int     an;
-   fixed_t z = actor->z + DEFAULTMISSILEZ;
+   fixed_t z = actor->z + actor->info->missilezoffset;
    int     FatShotType = E_SafeThingType(MT_FATSHOT);
 
    // haleyjd: no crashing
@@ -1475,7 +1475,7 @@ void A_BrainSpit(actionargs_t *actionargs)
    targ = braintargets.wrapIterator();
 
    // spawn brain missile
-   newmobj = P_SpawnMissile(mo, targ, SpawnShotType, mo->z + DEFAULTMISSILEZ);
+   newmobj = P_SpawnMissile(mo, targ, SpawnShotType, mo->z + mo->info->missilezoffset);
    P_SetTarget<Mobj>(&newmobj->target, targ);
    newmobj->reactiontime = (int16_t)(((targ->y-mo->y)/newmobj->momy)/newmobj->state->tics);
 

--- a/source/a_general.cpp
+++ b/source/a_general.cpp
@@ -91,7 +91,7 @@ void P_Mushroom(Mobj *actor, const int ShotType, const int n, const fixed_t misc
        
          mo = P_SpawnMissileWithDest(actor, actor, 
                                      ShotType,          // Launch fireball
-                                     actor->z + DEFAULTMISSILEZ,
+                                     actor->z + actor->info->missilezoffset,
                                      x, y, z);
          
          mo->momx = FixedMul(mo->momx, misc2);
@@ -919,7 +919,7 @@ void A_MissileAttack(actionargs_t *actionargs)
    ang = (angle_t)(((uint64_t)a << 32) / 360);
 
    // adjust z coordinate
-   z = actor->z + DEFAULTMISSILEZ + z;
+   z = actor->z + actor->info->missilezoffset + z;
 
    if(!hastarget)
    {
@@ -998,7 +998,7 @@ void A_MissileSpread(actionargs_t *actionargs)
    angsweep = (angle_t)(((uint64_t)a << 32) / 360);
 
    // adjust z coordinate
-   z = actor->z + DEFAULTMISSILEZ + z;
+   z = actor->z + actor->info->missilezoffset + z;
 
    ang = actor->angle - angsweep / 2;
    astep = angsweep / (num - 1);

--- a/source/a_general.cpp
+++ b/source/a_general.cpp
@@ -91,7 +91,7 @@ void P_Mushroom(Mobj *actor, const int ShotType, const int n, const fixed_t misc
        
          mo = P_SpawnMissileWithDest(actor, actor, 
                                      ShotType,          // Launch fireball
-                                     actor->z + actor->info->missilezoffset,
+                                     actor->z + actor->info->missileheight,
                                      x, y, z);
          
          mo->momx = FixedMul(mo->momx, misc2);
@@ -919,7 +919,7 @@ void A_MissileAttack(actionargs_t *actionargs)
    ang = (angle_t)(((uint64_t)a << 32) / 360);
 
    // adjust z coordinate
-   z = actor->z + actor->info->missilezoffset + z;
+   z = actor->z + actor->info->missileheight + z;
 
    if(!hastarget)
    {
@@ -998,7 +998,7 @@ void A_MissileSpread(actionargs_t *actionargs)
    angsweep = (angle_t)(((uint64_t)a << 32) / 360);
 
    // adjust z coordinate
-   z = actor->z + actor->info->missilezoffset + z;
+   z = actor->z + actor->info->missileheight + z;
 
    ang = actor->angle - angsweep / 2;
    astep = angsweep / (num - 1);

--- a/source/a_heretic.cpp
+++ b/source/a_heretic.cpp
@@ -177,7 +177,7 @@ void A_MummyAttack2(actionargs_t *actionargs)
    
    mo = P_SpawnMissile(actor, actor->target, 
                        E_SafeThingType(MT_MUMMYFX1),
-                       actor->z + actor->info->missilezoffset);
+                       actor->z + actor->info->missileheight);
 
    P_SetTarget<Mobj>(&mo->tracer, actor->target);
 }
@@ -363,7 +363,7 @@ void A_WizardAtk3(actionargs_t *actionargs)
    Mobj *mo;
    angle_t angle;
    fixed_t momz;
-   fixed_t z = actor->z + actor->info->missilezoffset;
+   fixed_t z = actor->z + actor->info->missileheight;
    int wizfxType = E_SafeThingType(MT_WIZFX1);
    
    actor->flags3 &= ~MF3_GHOST;
@@ -594,7 +594,7 @@ void A_Srcr2Attack(actionargs_t *actionargs)
 {
    Mobj *actor = actionargs->actor;
    int chance;
-   fixed_t z = actor->z + actor->info->missilezoffset;
+   fixed_t z = actor->z + actor->info->missileheight;
    int sor2fx1Type = E_SafeThingType(MT_SOR2FX1);
    int sor2fx2Type = E_SafeThingType(MT_SOR2FX2);
    
@@ -1121,7 +1121,7 @@ void A_BeastAttack(actionargs_t *actionargs)
    }
    else
       P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_BEASTBALL),
-                     actor->z + actor->info->missilezoffset);
+                     actor->z + actor->info->missileheight);
 }
 
 void A_BeastPuff(actionargs_t *actionargs)
@@ -1163,7 +1163,7 @@ void A_SnakeAttack(actionargs_t *actionargs)
    S_StartSound(actor, actor->info->attacksound);
    A_FaceTarget(actionargs);
    P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_SNAKEPRO_A),
-                  actor->z + actor->info->missilezoffset);
+                  actor->z + actor->info->missileheight);
 }
 
 void A_SnakeAttack2(actionargs_t *actionargs)
@@ -1180,7 +1180,7 @@ void A_SnakeAttack2(actionargs_t *actionargs)
    S_StartSound(actor, actor->info->attacksound);
    A_FaceTarget(actionargs);
    P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_SNAKEPRO_B),
-                  actor->z + actor->info->missilezoffset);
+                  actor->z + actor->info->missileheight);
 }
 
 //=============================================================================
@@ -1450,7 +1450,7 @@ void A_LichFire(actionargs_t *actionargs)
 
    // spawn the parent fireball
    baseFire = P_SpawnMissile(actor, target, headfxType, 
-                             actor->z + actor->info->missilezoffset);
+                             actor->z + actor->info->missileheight);
    
    // set it to S_HEADFX3_4 so that it doesn't grow
    P_SetMobjState(baseFire, frameNum);
@@ -1555,7 +1555,7 @@ void A_LichAttack(actionargs_t *actionargs)
    if(randAttack < (dist ? 150 : 50))
    {
       // ice attack
-      P_SpawnMissile(actor, target, fxType, actor->z + actor->info->missilezoffset);
+      P_SpawnMissile(actor, target, fxType, actor->z + actor->info->missileheight);
       S_StartSound(actor, sfx_hedat2);	
    }
    else if(randAttack < (dist ? 200 : 150))
@@ -1732,7 +1732,7 @@ void A_ImpMissileAtk(actionargs_t *actionargs)
                    5 + (P_Random(pr_impmelee2) & 7), MOD_HIT);
    }
    else
-      P_SpawnMissile(actor, actor->target, fxType, actor->z + actor->info->missilezoffset);
+      P_SpawnMissile(actor, actor->target, fxType, actor->z + actor->info->missileheight);
 }
 
 //

--- a/source/a_heretic.cpp
+++ b/source/a_heretic.cpp
@@ -177,7 +177,7 @@ void A_MummyAttack2(actionargs_t *actionargs)
    
    mo = P_SpawnMissile(actor, actor->target, 
                        E_SafeThingType(MT_MUMMYFX1),
-                       actor->z + DEFAULTMISSILEZ);
+                       actor->z + actor->info->missilezoffset);
 
    P_SetTarget<Mobj>(&mo->tracer, actor->target);
 }
@@ -363,7 +363,7 @@ void A_WizardAtk3(actionargs_t *actionargs)
    Mobj *mo;
    angle_t angle;
    fixed_t momz;
-   fixed_t z = actor->z + DEFAULTMISSILEZ;
+   fixed_t z = actor->z + actor->info->missilezoffset;
    int wizfxType = E_SafeThingType(MT_WIZFX1);
    
    actor->flags3 &= ~MF3_GHOST;
@@ -594,7 +594,7 @@ void A_Srcr2Attack(actionargs_t *actionargs)
 {
    Mobj *actor = actionargs->actor;
    int chance;
-   fixed_t z = actor->z + DEFAULTMISSILEZ;
+   fixed_t z = actor->z + actor->info->missilezoffset;
    int sor2fx1Type = E_SafeThingType(MT_SOR2FX1);
    int sor2fx2Type = E_SafeThingType(MT_SOR2FX2);
    
@@ -1121,7 +1121,7 @@ void A_BeastAttack(actionargs_t *actionargs)
    }
    else
       P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_BEASTBALL),
-                     actor->z + DEFAULTMISSILEZ);
+                     actor->z + actor->info->missilezoffset);
 }
 
 void A_BeastPuff(actionargs_t *actionargs)
@@ -1163,7 +1163,7 @@ void A_SnakeAttack(actionargs_t *actionargs)
    S_StartSound(actor, actor->info->attacksound);
    A_FaceTarget(actionargs);
    P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_SNAKEPRO_A),
-                  actor->z + DEFAULTMISSILEZ);
+                  actor->z + actor->info->missilezoffset);
 }
 
 void A_SnakeAttack2(actionargs_t *actionargs)
@@ -1180,7 +1180,7 @@ void A_SnakeAttack2(actionargs_t *actionargs)
    S_StartSound(actor, actor->info->attacksound);
    A_FaceTarget(actionargs);
    P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_SNAKEPRO_B),
-                  actor->z + DEFAULTMISSILEZ);
+                  actor->z + actor->info->missilezoffset);
 }
 
 //=============================================================================
@@ -1450,7 +1450,7 @@ void A_LichFire(actionargs_t *actionargs)
 
    // spawn the parent fireball
    baseFire = P_SpawnMissile(actor, target, headfxType, 
-                             actor->z + DEFAULTMISSILEZ);
+                             actor->z + actor->info->missilezoffset);
    
    // set it to S_HEADFX3_4 so that it doesn't grow
    P_SetMobjState(baseFire, frameNum);
@@ -1555,7 +1555,7 @@ void A_LichAttack(actionargs_t *actionargs)
    if(randAttack < (dist ? 150 : 50))
    {
       // ice attack
-      P_SpawnMissile(actor, target, fxType, actor->z + DEFAULTMISSILEZ);
+      P_SpawnMissile(actor, target, fxType, actor->z + actor->info->missilezoffset);
       S_StartSound(actor, sfx_hedat2);	
    }
    else if(randAttack < (dist ? 200 : 150))
@@ -1732,7 +1732,7 @@ void A_ImpMissileAtk(actionargs_t *actionargs)
                    5 + (P_Random(pr_impmelee2) & 7), MOD_HIT);
    }
    else
-      P_SpawnMissile(actor, actor->target, fxType, actor->z + DEFAULTMISSILEZ);
+      P_SpawnMissile(actor, actor->target, fxType, actor->z + actor->info->missilezoffset);
 }
 
 //

--- a/source/e_things.cpp
+++ b/source/e_things.cpp
@@ -220,6 +220,10 @@ int UnknownThingType;
 #define ITEM_TNG_PFX_SOUND     "sound"
 #define ITEM_TNG_PFX_FLAGS     "flags"
 
+// Attack Z offset properties (there's two in reality)
+#define ITEM_TNG_MISSILEZOFFSET "missilezoffset"
+#define ITEM_TNG_BULLETZOFFSET  "bulletzoffset"
+
 //
 // Thing groups
 //
@@ -600,6 +604,8 @@ static int E_TranMapCB(cfg_t *, cfg_opt_t *, const char *, void *);
    CFG_STR(ITEM_TNG_BLOODRIP,        "",            CFGF_NONE                ), \
    CFG_STR(ITEM_TNG_BLOODCRUSH,      "",            CFGF_NONE                ), \
    CFG_SEC(ITEM_TNG_PFX_PICKUPFX,    tngpfx_opts,   CFGF_NOCASE              ), \
+   CFG_FLOAT(ITEM_TNG_MISSILEZOFFSET,32.0f,         CFGF_NONE                ), \
+   CFG_FLOAT(ITEM_TNG_BULLETZOFFSET, 8.0f,          CFGF_NONE                ), \
    CFG_END()
 
 cfg_opt_t edf_thing_opts[] =
@@ -2979,6 +2985,18 @@ void E_ProcessThing(int i, cfg_t *thingsec, cfg_t *pcfg, bool def)
          if(flags & gameTypeToACSFlags[GameModeInfo->type])
             ACS_thingtypes[tempint] = i;
       }
+   }
+
+   // [XA] 03-03-2020: process attack z offsets
+   if(IS_SET(ITEM_TNG_MISSILEZOFFSET))
+   {
+      tempfloat = cfg_getfloat(thingsec, ITEM_TNG_MISSILEZOFFSET);
+      mobjinfo[i]->missilezoffset = (int)(tempfloat * FRACUNIT);
+   }
+   if(IS_SET(ITEM_TNG_BULLETZOFFSET))
+   {
+      tempfloat = cfg_getfloat(thingsec, ITEM_TNG_BULLETZOFFSET);
+      mobjinfo[i]->bulletzoffset = (int)(tempfloat * FRACUNIT);
    }
 
    // Process DECORATE state block

--- a/source/e_things.cpp
+++ b/source/e_things.cpp
@@ -221,8 +221,8 @@ int UnknownThingType;
 #define ITEM_TNG_PFX_FLAGS     "flags"
 
 // Attack Z offset properties (there's two in reality)
-#define ITEM_TNG_MISSILEZOFFSET "missilezoffset"
-#define ITEM_TNG_BULLETZOFFSET  "bulletzoffset"
+#define ITEM_TNG_MISSILEHEIGHT "missileheight"
+#define ITEM_TNG_BULLETZOFFSET "bulletzoffset"
 
 //
 // Thing groups
@@ -604,7 +604,7 @@ static int E_TranMapCB(cfg_t *, cfg_opt_t *, const char *, void *);
    CFG_STR(ITEM_TNG_BLOODRIP,        "",            CFGF_NONE                ), \
    CFG_STR(ITEM_TNG_BLOODCRUSH,      "",            CFGF_NONE                ), \
    CFG_SEC(ITEM_TNG_PFX_PICKUPFX,    tngpfx_opts,   CFGF_NOCASE              ), \
-   CFG_FLOAT(ITEM_TNG_MISSILEZOFFSET,32.0f,         CFGF_NONE                ), \
+   CFG_FLOAT(ITEM_TNG_MISSILEHEIGHT, 32.0f,         CFGF_NONE                ), \
    CFG_FLOAT(ITEM_TNG_BULLETZOFFSET, 8.0f,          CFGF_NONE                ), \
    CFG_END()
 
@@ -2988,10 +2988,10 @@ void E_ProcessThing(int i, cfg_t *thingsec, cfg_t *pcfg, bool def)
    }
 
    // [XA] 03-03-2020: process attack z offsets
-   if(IS_SET(ITEM_TNG_MISSILEZOFFSET))
+   if(IS_SET(ITEM_TNG_MISSILEHEIGHT))
    {
-      tempfloat = cfg_getfloat(thingsec, ITEM_TNG_MISSILEZOFFSET);
-      mobjinfo[i]->missilezoffset = (int)(tempfloat * FRACUNIT);
+      tempfloat = cfg_getfloat(thingsec, ITEM_TNG_MISSILEHEIGHT);
+      mobjinfo[i]->missileheight = (int)(tempfloat * FRACUNIT);
    }
    if(IS_SET(ITEM_TNG_BULLETZOFFSET))
    {

--- a/source/info.h
+++ b/source/info.h
@@ -423,7 +423,7 @@ struct mobjinfo_t
    int activatesound;   // haleyjd 03/19/11: Hexen activation sound
    int deactivatesound; // haleyjd 03/19/11: Hexen deactivation sound
    int gibhealth;       // haleyjd 09/12/13: health at which actor gibs
-   int missilezoffset;  // [XA] 03/03/2020: Z offset (from bottom) for missile attacks
+   int missileheight;  // [XA] 03/03/2020: Z offset (from bottom) for missile attacks
    int bulletzoffset;   // [XA] 03/03/2020: Z offset (from center) for bullet attacks
 
    e_pickupfx_t *pickupfx;

--- a/source/info.h
+++ b/source/info.h
@@ -423,6 +423,8 @@ struct mobjinfo_t
    int activatesound;   // haleyjd 03/19/11: Hexen activation sound
    int deactivatesound; // haleyjd 03/19/11: Hexen deactivation sound
    int gibhealth;       // haleyjd 09/12/13: health at which actor gibs
+   int missilezoffset;  // [XA] 03/03/2020: Z offset (from bottom) for missile attacks
+   int bulletzoffset;   // [XA] 03/03/2020: Z offset (from center) for bullet attacks
 
    e_pickupfx_t *pickupfx;
 

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -3113,7 +3113,7 @@ Mobj *P_SpawnPlayerMissile(Mobj* source, mobjtype_t type, playermissilemode_e mo
 
    x = source->x;
    y = source->y;
-   z = source->z + 4*8*FRACUNIT - source->floorclip +
+   z = source->z + source->info->missilezoffset - source->floorclip +
          (mode == playermissilemode_e::heretic ? playersightslope : 0);
 
    th = P_SpawnMobj(x, y, z, type);

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -3113,7 +3113,7 @@ Mobj *P_SpawnPlayerMissile(Mobj* source, mobjtype_t type, playermissilemode_e mo
 
    x = source->x;
    y = source->y;
-   z = source->z + source->info->missilezoffset - source->floorclip +
+   z = source->z + source->info->missileheight - source->floorclip +
          (mode == playermissilemode_e::heretic ? playersightslope : 0);
 
    th = P_SpawnMobj(x, y, z, type);

--- a/source/p_mobj.h
+++ b/source/p_mobj.h
@@ -75,7 +75,7 @@ class  BloodSpawner;
 #define OVERDRIVE 6
 #define MAXGEAR (OVERDRIVE+16)
 
-// [XA] DEFAULTMISSILEZ is now a mobjinfo property (missilezoffset)
+// [XA] DEFAULTMISSILEZ is now a mobjinfo property (missileheight)
 
 #define NUMMOBJCOUNTERS 8
 

--- a/source/p_mobj.h
+++ b/source/p_mobj.h
@@ -75,8 +75,7 @@ class  BloodSpawner;
 #define OVERDRIVE 6
 #define MAXGEAR (OVERDRIVE+16)
 
-// haleyjd 11/28/02: default z coord addend for missile spawn
-#define DEFAULTMISSILEZ (4*8*FRACUNIT)
+// [XA] DEFAULTMISSILEZ is now a mobjinfo property (missilezoffset)
 
 #define NUMMOBJCOUNTERS 8
 

--- a/source/p_trace.cpp
+++ b/source/p_trace.cpp
@@ -651,7 +651,7 @@ void P_LineAttack(Mobj *t1, angle_t angle, fixed_t distance,
    x2 = t1->x + (distance >> FRACBITS) * (trace.cos = finecosine[angle]);
    y2 = t1->y + (distance >> FRACBITS) * (trace.sin = finesine[angle]);
    
-   trace.z = t1->z - t1->floorclip + (t1->height>>1) + 8*FRACUNIT;
+   trace.z = t1->z - t1->floorclip + (t1->height>>1) + (t1->info->bulletzoffset);
    trace.attackrange = distance;
    trace.aimslope = slope;
 


### PR DESCRIPTION
Couple o' new thing properties:
- **missileheight**: Height to spawn missile attacks at (relative to actor's z position).
- **bulletzoffset**: Z-offset for bullet attacks (relative to actor's _center_ -- that's how these two properties work internally, so they're named differently to suit).

I had a change of heart on adding these; originally I figured parameterizing the various action functions would suffice, but on second thought, I figured this was gonna be a pain point for modders (e.g. "I can change the player's viewheight but all the attacks are wrong unless I change _every_ weapon, WTF"). That and this is just de-hardcoding a couple of constant values anyway, so hey! Win-win.