### PR TITLE
A_SelfDestruct action function

### DIFF
--- a/source/a_general.cpp
+++ b/source/a_general.cpp
@@ -1668,5 +1668,22 @@ void A_DetonateEx(actionargs_t *actionargs)
    E_ExplosionHitWater(actor, radius);
 }
 
+//
+// A_SelfDestruct
+//
+// Detonates a missile mid-flight.
+// If actor is not a missile, A_Die
+// is called instead. 'Nuff said.
+//
+void A_SelfDestruct(actionargs_t *actionargs)
+{
+   Mobj *actor = actionargs->actor;
+
+   if(clip.thing->flags & (MF_MISSILE | MF_BOUNCES))
+      P_ExplodeMissile(actor, nullptr);
+   else
+      A_Die(actionargs);
+}
+
 // EOF
 

--- a/source/a_general.cpp
+++ b/source/a_general.cpp
@@ -1679,7 +1679,7 @@ void A_SelfDestruct(actionargs_t *actionargs)
 {
    Mobj *actor = actionargs->actor;
 
-   if(clip.thing->flags & (MF_MISSILE | MF_BOUNCES))
+   if(actor->flags & (MF_MISSILE | MF_BOUNCES))
       P_ExplodeMissile(actor, nullptr);
    else
       A_Die(actionargs);

--- a/source/d_dehtbl.cpp
+++ b/source/d_dehtbl.cpp
@@ -1386,6 +1386,7 @@ void A_RestoreArtifact(actionargs_t *);
 void A_RestoreSpecialThing1(actionargs_t *);
 void A_RestoreSpecialThing2(actionargs_t *);
 void A_SargAttack12(actionargs_t *actionargs);
+void A_SelfDestruct(actionargs_t *);
 
 // haleyjd 10/12/02: Heretic pointers
 void A_SpawnTeleGlitter(actionargs_t *actionargs);
@@ -1738,6 +1739,7 @@ deh_bexptr deh_bexptrs[] =
    POINTER(RestoreSpecialThing1),
    POINTER(RestoreSpecialThing2),
    POINTER(SargAttack12),
+   POINTER(SelfDestruct),
 
    // haleyjd 07/13/03: nuke specials
    POINTER(PainNukeSpec),


### PR DESCRIPTION
I couldn't figure out a satisfactory way to detonate a projectile mid-flight, so I made an `A_SelfDestruct` codepointer that does just that.

As a fallback, if the actor in question isn't a missile (or an MF_BOUNCES motherfucker), it calls A_Die. Should make things nice n' safe n' straightforward n' stuff.