### PR TITLE
add option to always pass use key through special lines like prboom-plus

### DIFF
--- a/source/c_net.h
+++ b/source/c_net.h
@@ -96,6 +96,7 @@ enum
   netcmd_comp_ninja,       //          ninja spawn
   netcmd_comp_jump,        // ioanch:  air control for jumping
   netcmd_comp_aircontrol = netcmd_comp_jump,
+  netcmd_comp_passuse,
   NUMNETCMDS
 };
 

--- a/source/cam_use.cpp
+++ b/source/cam_use.cpp
@@ -28,6 +28,7 @@
 #include "cam_sight.h"
 #include "d_gi.h"
 #include "d_player.h"
+#include "doomstat.h"
 #include "e_exdata.h"
 #include "p_map.h"
 #include "p_mobj.h"
@@ -149,7 +150,7 @@ bool UseContext::useTraverse(const intercept_t *in, void *vcontext,
 
       //WAS can't use for than one special line in a row
       //jff 3/21/98 NOW multiple use allowed with enabling line flag
-      return !!(li->flags & ML_PASSUSE);
+      return !!((li->flags & ML_PASSUSE) || comp[comp_passuse]);
    }
 
    // no special

--- a/source/doomstat.h
+++ b/source/doomstat.h
@@ -160,6 +160,7 @@ enum {
   comp_ninja,       //         04/18/10: ninja spawn in G_CheckSpot
   comp_jump,        // Disable jumping and air control
   comp_aircontrol = comp_jump,
+  comp_passuse,
   COMP_NUM_USED,    // counts the used comps. MUST BE LAST ONE + 1.
   COMP_TOTAL=32  // Some extra room for additional variables
 };

--- a/source/g_cmd.cpp
+++ b/source/g_cmd.cpp
@@ -799,7 +799,8 @@ const char *comp_strings[] =
   "planeshoot", //          09/22/07: plane shooting
   "special",    //          08/29/09: special failure behavior
   "ninja",      //          04/18/10: ninja spawn
-  "aircontrol"
+  "aircontrol",
+  "passuse"
 };
 
 static void Handler_CompTHeights()

--- a/source/g_game.cpp
+++ b/source/g_game.cpp
@@ -1041,6 +1041,7 @@ struct complevel_s
    { 335, 335 }, // comp_special
    { 337, 337 }, // comp_ninja
    { 340, 340 }, // comp_jump
+   { 401, 401 }, // comp_passuse
    { 0,   0   }
 };
 

--- a/source/m_misc.cpp
+++ b/source/m_misc.cpp
@@ -458,6 +458,9 @@ default_t defaults[] =
    DEFAULT_INT("comp_aircontrol", &default_comp[comp_aircontrol], &comp[comp_aircontrol],
                1, 0, 1, default_t::wad_yes, "Disable jumping for DOOM/Heretic"),
 
+   DEFAULT_INT("comp_passuse", &default_comp[comp_passuse], &comp[comp_passuse],
+               0, 0, 1, default_t::wad_yes, "Use key passes through all special lines"),
+
    // For key bindings, the values stored in the key_* variables       // phares
    // are the internal Doom Codes. The values stored in the default.cfg
    // file are the keyboard codes. I_ScanCode2DoomCode converts from

--- a/source/mn_menus.cpp
+++ b/source/mn_menus.cpp
@@ -3203,6 +3203,7 @@ static menuitem_t mn_compat3_items[] =
    { it_toggle, "Use DOOM linedef trigger model",       "comp_model"     },
    { it_toggle, "Line effects work on sector tag 0",    "comp_zerotags"  },
    { it_toggle, "One-time line effects can break",      "comp_special"   },
+   { it_toggle, "Use key can activate multiple lines",  "comp_passuse"   },
    { it_end }
 };
 

--- a/source/p_trace.cpp
+++ b/source/p_trace.cpp
@@ -678,7 +678,8 @@ static bool PTR_UseTraverse(intercept_t *in, void *context)
 
       //WAS can't use for than one special line in a row
       //jff 3/21/98 NOW multiple use allowed with enabling line flag
-      return (!demo_compatibility && in->d.line->flags & ML_PASSUSE);
+      return (!demo_compatibility &&
+              ((in->d.line->flags & ML_PASSUSE) || comp[comp_passuse]));
    }
    else
    {


### PR DESCRIPTION
prboom-plus has an option to treat all special lines as having ML_PASSUSE set, which is needed for cchest2.wad MAP24 (and possibly other "Boom-compatible-but-not-quite" maps) to be completable. This adds that option, disabled by default.

Also attached a dumb test map as a more obvious/contrived example.
[passusetest.zip](https://github.com/team-eternity/eternity/files/4430749/passusetest.zip)

