### PR TITLE
Make the save/load menus use the proper title graphics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ SDL2_net.framework
 .vscode
 *.VC.db
 vc2017/Debug/
+.dir-locals.el

--- a/source/mn_menus.cpp
+++ b/source/mn_menus.cpp
@@ -1435,7 +1435,13 @@ static void MN_LoadGameDrawer()
 {
    static char *emptystr = NULL;
 
-   V_DrawPatch(72, 18, &subscreen43, PatchLoader::CacheName(wGlobalDir, "M_LOADG", PU_CACHE));
+   int lumpnum = W_CheckNumForName("M_LGTTL");
+
+   if(mn_classic_menus || lumpnum == -1)
+      lumpnum = W_CheckNumForName("M_LOADG");
+
+   V_DrawPatch(72, 18, &subscreen43,
+               PatchLoader::CacheNum(wGlobalDir, lumpnum, PU_CACHE));
 
    if(!emptystr)
       emptystr = estrdup(DEH_String("EMPTYSTRING"));
@@ -1573,7 +1579,13 @@ menu_t menu_savegame =
 
 static void MN_SaveGameDrawer()
 {
-   V_DrawPatch(72, 18, &subscreen43, PatchLoader::CacheName(wGlobalDir, "M_SAVEG", PU_CACHE));
+   int lumpnum = W_CheckNumForName("M_SGTTL");
+
+   if(mn_classic_menus || lumpnum == -1)
+      lumpnum = W_CheckNumForName("M_SAVEG");
+
+   V_DrawPatch(72, 18, &subscreen43,
+               PatchLoader::CacheNum(wGlobalDir, lumpnum, PU_CACHE));
 
    for(int i = 0; i < SAVESLOTS; i++)
       MN_DrawSaveLoadBorder(menu_savegame.x, menu_savegame.y + 16*i);

--- a/source/v_patchfmt.cpp
+++ b/source/v_patchfmt.cpp
@@ -243,7 +243,10 @@ bool PatchLoader::VerifyAndFormat(void *data, size_t size)
 //
 patch_t *PatchLoader::CacheNum(WadDirectory &dir, int lumpnum, int tag)
 {
-   return static_cast<patch_t *>(dir.cacheLumpNum(lumpnum, tag, &patchFmt));
+   if(lumpnum >= 0)
+      return static_cast<patch_t *>(dir.cacheLumpNum(lumpnum, tag, &patchFmt));
+   else
+      return GetDefaultPatch();
 }
 
 //
@@ -253,15 +256,7 @@ patch_t *PatchLoader::CacheNum(WadDirectory &dir, int lumpnum, int tag)
 //
 patch_t *PatchLoader::CacheName(WadDirectory &dir, const char *name, int tag, int ns)
 {
-   int lumpnum;
-   patch_t *ret;
-
-   if((lumpnum = dir.checkNumForName(name, ns)) >= 0)
-      ret = PatchLoader::CacheNum(dir, lumpnum, tag);
-   else
-      ret = GetDefaultPatch();
-
-   return ret;
+   return PatchLoader::CacheNum(dir, dir.checkNumForName(name, ns), tag);
 }
 
 //


### PR DESCRIPTION
Additionally, this makes `PatchLoader::CacheNum` far safer to use, fixing many potential crashes when graphics are missing.