### PR TITLE
Use int for characters compared against EOF

### DIFF
--- a/source/m_misc.cpp
+++ b/source/m_misc.cpp
@@ -1539,7 +1539,7 @@ void M_SaveDefaultFile(defaultfile_t *df)
       return;
    }
 
-   for(char ch = fgetc(f); ch != EOF; ch = fgetc(f))
+   for(int ch = fgetc(f); ch != EOF; ch = fgetc(f))
       fputc(ch, destf);
 
    // We don't care about errors at this stage


### PR DESCRIPTION
EOF cannot be represented as a char on all platforms, for example ARM
on which char is unsigned.
