### PR TITLE
Add 'levelnum' variable to EMAPINFO

### DIFF
--- a/source/g_game.cpp
+++ b/source/g_game.cpp
@@ -95,6 +95,7 @@
 #include "version.h"
 #include "w_levels.h" // haleyjd
 #include "w_wad.h"
+#include "xl_emapinfo.h"
 
 // haleyjd: new demo format stuff
 static char     eedemosig[] = "ETERN";
@@ -1780,10 +1781,18 @@ enum levelkind_t
 //
 static const char *G_getNextLevelName(levelkind_t kind, int map)
 {
-   const char *nextName = kind == lk_secret ? LevelInfo.nextSecret :
-   LevelInfo.nextLevel;
-   if(!wminfo.nextexplicit && nextName && *nextName)
+   const char *nextName = nullptr;
+
+   if(wminfo.nextexplicit)
+      // derekmd: for Teleport_NewMap() calls, detect EMAPINFO 'levelnum'
+      nextName = XL_MapNameForLevelNum(map);
+   else
+      nextName = kind == lk_secret ?
+         LevelInfo.nextSecret : LevelInfo.nextLevel;
+
+   if(nextName && *nextName)
       return nextName;
+
    return G_GetNameForMap(gameepisode, map);
 }
 

--- a/source/xl_emapinfo.cpp
+++ b/source/xl_emapinfo.cpp
@@ -353,7 +353,7 @@ MetaTable *XL_EMapInfoForMapName(const char *mapname)
 //
 // XL_EMapInfoForMapNum
 //
-// Retrieve and EMAPINFO definition by episode and map. Send in episode
+// Retrieve an EMAPINFO definition by episode and map. Send in episode
 // 0 for MAPxy maps.
 //
 MetaTable *XL_EMapInfoForMapNum(int episode, int map)
@@ -366,6 +366,29 @@ MetaTable *XL_EMapInfoForMapNum(int episode, int map)
       mapname.Printf(9, "MAP%02d", map);
 
    return emapInfoTable.getObjectKeyAndTypeEx<MetaTable>(mapname.constPtr());
+}
+
+//
+// XL_MapNameForLevelNum
+//
+// Retrieve the map name by EMAPINFO levelnum.
+//
+const char* XL_MapNameForLevelNum(int map)
+{
+   MetaTable* level = nullptr;
+   qstring levelnum;
+
+   levelnum.Printf(2, "%d", map);
+
+   while((level = emapInfoTable.getNextTypeEx(level)))
+   {
+      auto str = level->getString("levelnum", "");
+
+      if(*str && strcmp(str, levelnum.constPtr()) == 0)
+         return level->getKey();
+   }
+
+   return nullptr;
 }
 
 //

--- a/source/xl_emapinfo.h
+++ b/source/xl_emapinfo.h
@@ -34,6 +34,7 @@ class WadDirectory;
 
 MetaTable *XL_EMapInfoForMapName(const char *mapname);
 MetaTable *XL_EMapInfoForMapNum(int episode, int map);
+const char *XL_MapNameForLevelNum(int map);
 void       XL_ParseEMapInfo();
 MetaTable *XL_ParseLevelInfo(WadDirectory *dir, int lumpnum);
 


### PR DESCRIPTION
Fixes: https://github.com/team-eternity/eternity/issues/150

When PWAD map names don't follow the format `ExMy` or `MAPxx`, it isn't possible to use ACS function `Teleport_NewMap()` / linedef type 74 for exiting to another arbitrary map. By adding a new `levelnum` integer variable to `EMAPINFO`, it's possible for devs to define their custom map number. This naming matches ZDoom's `ZMAPINFO` variable.

e.g., `EMAPINFO` file:

```
[D2DM1]
levelname = Intro
partime = 30
skyname = SKY1
levelnum = 1

[D2DM2]
levelname = End
partime = 30
skyname = SKY1
levelnum = 2
```

> When currently playing D2DM1, calling `Teleport_NumMap(2)` will now continue to `D2DM2` instead of `MAP02` or `ExM2`.

For testing, here's a Demo WAD containing 3 UDMF maps with exits to any given level: [eternity-emapinfo-levelnum.zip](https://github.com/team-eternity/eternity/files/5578449/eternity-emapinfo-levelnum.zip)

This `levelnum` addition does not consider:

* `IDCLEV` cheat code
* `-warp` parameter

It's more a level designer feature than something for players. They can use the console command `map` to reach the level.