### PR TITLE
Fix segfault on Heartland MAP02 when the dmflags for respawning items is enabled

### DIFF
--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -2182,6 +2182,16 @@ void P_RespawnSpecials()
       return;
 
    mthing = &itemrespawnque[iquetail];
+    
+    // find which type to spawn
+    
+    // killough 8/23/98: use table for faster lookup
+    i = P_FindDoomedNum(mthing->type);
+    
+    if (i == -1 || i == NUMMOBJTYPES) {
+       iquetail = (iquetail+1)&(ITEMQUESIZE-1);
+       return;
+    }
 
    x = mthing->x;
    y = mthing->y;
@@ -2190,11 +2200,6 @@ void P_RespawnSpecials()
    ss = R_PointInSubsector(x,y);
    mo = P_SpawnMobj(x, y, ss->sector->srf.floor.height, E_SafeThingType(MT_IFOG));
    S_StartSound(mo, sfx_itmbk);
-
-   // find which type to spawn
-
-   // killough 8/23/98: use table for faster lookup
-   i = P_FindDoomedNum(mthing->type);
 
    // spawn it
    z = mobjinfo[i]->flags & MF_SPAWNCEILING ? ONCEILINGZ : ONFLOORZ;


### PR DESCRIPTION
There might be a better way to do this, but I noticed if I turn on respawning items via dmflags and play through Heartland MAP02, right after getting to the building with the blue key inside, the game segfaults about 30 seconds later.

What I noticed in the debugger is that mobjinfo[i] is null which is what causes the segfault, and i is equal to NUMMOBJTYPES. I used grep to search for other uses of P_FindDoomedNum in the same file and found that the other usage checks I for -1 or being equal to NUMMOBJTYPES, and skip if so. I simply did the same thing for P_RespawnSpecials, also making sure to pull it from the queue before returning.