### PR TITLE
MBF21 A_FindTracer range arg fix

### DIFF
--- a/source/a_mbf21.cpp
+++ b/source/a_mbf21.cpp
@@ -363,7 +363,7 @@ void A_FindTracer(actionargs_t *actionargs)
       return;
 
    fov   = FixedToAngle(E_ArgAsFixed(args, 0, 0));
-   range = E_ArgAsInt(args, 0, 10) * MAPBLOCKSIZE;
+   range = E_ArgAsInt(args, 1, 10) * MAPBLOCKSIZE;
 
    if(fov == 0)
       fov = ANG360;


### PR DESCRIPTION
Just a small lil' PR -- A_FindTracer was accidentally pulling the "range" param from arg 0 instead of 1 -- this broke Vesper's seeking weapons, but everything with the mod seems to work nicely now after the fix. :D