### PR TITLE
Consider actor->z when spawning mbf21 custom monster projectile

### DIFF
--- a/source/a_mbf21.cpp
+++ b/source/a_mbf21.cpp
@@ -156,7 +156,7 @@ void A_MonsterProjectile(actionargs_t *actionargs)
    spawnofs_z  = E_ArgAsFixed(args, 4, 0);
 
    A_FaceTarget(actionargs);
-   mo = P_SpawnMissile(actor, actor->target, thingtype, DEFAULTMISSILEZ);
+   mo = P_SpawnMissile(actor, actor->target, thingtype, actor->z + DEFAULTMISSILEZ);
    if(!mo)
       return;
 


### PR DESCRIPTION
Projectiles are spawning at the incorrect height in Eternity when using the MBF21 A_MonsterProjectile DeHackEd codepointer. This change makes it consistent with calls to P_SpawnMissile in the default monster projectile code pointers in a_doom.cpp.

Seems to work correctly now when testing in game.