### PR TITLE
doom.wad & doom2.wad negative Y-offset texture patches reset to 0

### DIFF
--- a/source/d_gi.cpp
+++ b/source/d_gi.cpp
@@ -1583,11 +1583,11 @@ static gamemodeinfo_t giDoomCommercial =
    "DSSECRET",         // secretSoundName
    sfx_itmbk,          // defSecretSound
 
-   3,              // switchEpisode
-   &Doom2SkyData,  // skyData
-   nullptr,        // TextureHacks
-   DoomSkyFlats,   // skyFlats
-   &giPsprNoScale, // pspriteGlobalScale
+   3,                   // switchEpisode
+   &Doom2SkyData,       // skyData
+   R_Doom2TextureHacks, // TextureHacks
+   DoomSkyFlats,        // skyFlats
+   &giPsprNoScale,      // pspriteGlobalScale
 
    nullptr,          // defaultORs
 

--- a/source/r_textur.cpp
+++ b/source/r_textur.cpp
@@ -414,6 +414,73 @@ static void R_DetectTextureFormat(texturelump_t *tlump)
 }
 
 //
+// R_Doom2TextureHacks
+//
+// GameModeInfo routine to fix up bad Doom II textures
+//
+void R_Doom2TextureHacks(texture_t *t)
+{
+   if(t->ccount == 8 &&
+      t->height == 128 &&
+      t->components[5].originy == -16 &&
+      t->components[6].originy == -1 &&
+      strcmp(t->name, "BROWN144") == 0)
+   {
+      t->components[5].originy = t->components[6].originy = 0;
+   }
+   else if(t->ccount == 3 &&
+      t->height == 72 &&
+      t->components[0].originy == -8 &&
+      strcmp(t->name, "GRAY2") == 0)
+   {
+      t->components[0].originy = 0;
+   }
+   else if(t->ccount == 5 &&
+      t->height == 128 &&
+      t->components[2].originy == -16 &&
+      t->components[3].originy == -16 &&
+      strcmp(t->name, "GRAYVINE") == 0)
+   {
+      t->components[2].originy = t->components[3].originy = 0;
+   }
+   else if(t->ccount == 2 &&
+      t->height == 16 &&
+      t->components[0].originy == -112 &&
+      strcmp(t->name, "STEP2") == 0)
+   {
+      t->components[0].originy = 0;
+   }
+   else if(t->ccount == 5 &&
+      t->height == 128 &&
+      t->components[3].originy == -16 &&
+      strcmp(t->name, "SW1DIRT") == 0)
+   {
+      t->components[3].originy = 0;
+   }
+   else if(t->ccount == 5 &&
+      t->height == 128 &&
+      t->components[3].originy == -1 &&
+      strcmp(t->name, "SW2DIRT") == 0)
+   {
+      t->components[3].originy = 0;
+   }
+   else if(t->ccount == 3 &&
+      t->height == 128 &&
+      t->components[0].originy == -16 &&
+      (strcmp(t->name, "SW1VINE") == 0 || strcmp(t->name, "SW2VINE") == 0))
+   {
+      t->components[0].originy = 0;
+   }
+   else if(t->ccount == 2 &&
+      t->height == 128 &&
+      t->components[0].originy == -27 &&
+      strcmp(t->name, "TEKWALL1") == 0)
+   {
+      t->components[0].originy = 0;
+   }
+}
+
+//
 // R_DoomTextureHacks
 //
 // GameModeInfo routine to fix up bad Doom textures
@@ -423,30 +490,44 @@ void R_DoomTextureHacks(texture_t *t)
    // Adapted from Zdoom's FMultiPatchTexture::CheckForHacks
    if(t->ccount == 1 &&
       t->height == 128 &&
-      t->name[0] == 'S' &&
-      t->name[1] == 'K' &&
-      t->name[2] == 'Y' &&
-      t->name[3] == '1' &&
-      t->name[4] == 0)
+      strcmp(t->name, "SKY1") == 0)
    {
       t->components->originy = 0;
    }
-
-   // BIGDOOR7 in Doom also has patches at y offset -4 instead of 0.
-   if(t->ccount == 2 &&
+   else if(t->ccount == 2 &&
       t->height == 128 &&
       t->components[0].originy == -4 &&
       t->components[1].originy == -4 &&
-      t->name[0] == 'B' &&
-      t->name[1] == 'I' &&
-      t->name[2] == 'G' &&
-      t->name[3] == 'D' &&
-      t->name[4] == 'O' &&
-      t->name[5] == 'O' &&
-      t->name[6] == 'R' &&
-      t->name[7] == '7')
+      strcmp(t->name, "BIGDOOR7") == 0)
    {
       t->components[0].originy = t->components[1].originy = 0;
+   }
+   else if(t->ccount == 8 &&
+      t->height == 128 &&
+      t->components[5].originy == -16 &&
+      t->components[6].originy == -1 &&
+      strcmp(t->name, "BROWN144") == 0)
+   {
+      t->components[5].originy = t->components[6].originy = 0;
+   }
+   else if(t->ccount == 4 &&
+      t->height == 128 &&
+      t->components[2].originy == -2 &&
+      t->components[3].originy == -2 &&
+      strcmp(t->name, "COMPOHSO") == 0)
+   {
+      t->components[2].originy = t->components[3].originy = 0;
+   }
+   else if(t->ccount == 1 &&
+      t->height == 128 &&
+      t->components[0].originy == -8 &&
+      strcmp(t->name, "TEKWALL5") == 0)
+   {
+      t->components[0].originy = 0;
+   }
+   else
+   {
+      R_Doom2TextureHacks(t);
    }
 }
 

--- a/source/r_textur.h
+++ b/source/r_textur.h
@@ -30,6 +30,7 @@ struct texture_t;
 
 // Needed by GameModeInfo
 void R_DoomTextureHacks(texture_t *);
+void R_Doom2TextureHacks(texture_t *);
 void R_HticTextureHacks(texture_t *);
 
 #endif


### PR DESCRIPTION
## Vanilla behavior for IWAD texture patch Y-offsets

https://doomwiki.org/wiki/Vertical_offsets_are_ignored_in_texture_patches top half under header "Negative Offsets"

Vanilla would ignore y-offset patches with a negative value, instead resetting their top offset to 0. However both doom.wad and doom2.wad contain textures with patches above Y-offset 0.

With Eternity Engine carrying over a ZDoom behavioral adjustment for the above, negative Y-offsets are now permitted. However a dozen IWAD textures display without pixel precision of vanilla. ZDoom hardcoded fixes for doom.wad `SKY1` & `BIGDOOR7`, also carried over to EE, and there are additional entries requiring a fix in ZDoom-extending source ports. Mostly feature-less `BROWN*` and `GRAY*` patches are not visually noticeable but pattern materials in `COMPOHSO`, `TEKWALL1`, and `TEKWALL5` clearly don't align to geometry when expected.

## Example WAD

Sample doom.wad E1M1 PWAD for testing the obvious textures: [test-neg-y-offsets.zip](https://github.com/team-eternity/eternity/files/10299250/test-neg-y-offsets.zip)

Eternity Engine v4.0.2:

![eternity-4 02](https://user-images.githubusercontent.com/823566/209453007-da75c64d-4d93-4619-9a97-2121bedcb882.png)

With this PR applied, matching Chocolate Doom patch offsets:

![eternity-dev-pr](https://user-images.githubusercontent.com/823566/209453021-5a94110e-b78c-433c-816a-6a5915c7c90d.png)

## List of IWAD textures containing a negative y-offset patch

### doom.wad `TEXTURE1` entries:
* SKY1 (already fixed)
* BROWN144
* SW1DIRT
* SW2DIRT
* TEKWALL1
* TEKWALL5

### doom.wad `TEXTURE2` entries
* BIGDOOR7 (already fixed)
* COMPOHSO
* GRAY2
* GRAYVINE
* SW1VINE
* SW2VINE

### doom2.wad `TEXTURE1` entries

doom2.wad negative offsets are a subset of doom.wad, however it fixes `BIGDOOR7` back to offset 0. doom2.wad also introduces another ignored negative offset -112 in `STEP2` as screenshot'd in the Wiki article.

* BROWN144
* GRAY2
* GRAYVINE
* STEP2
* SW1DIRT
* SW2DIRT
* SW1VINE
* SW2VINE
* TEKWALL1

### tnt.wad `TEXTURE1` additional entries

This PR doesn't address these as the misalignments look like genuine bugs in textures mostly used in MAP11. Negative offset blood spatter is meant to align with crate edges and allowing negative offsets fixes that.

* CRBLWDH6 (BLOD64A at -1)
* CR64HBBP (BLOD64A at -21)
* CRBWHBP (BUL64C at -5)
* CRBWLBP (BLOD64A at -47)
* CRAWLBP (BLOD128A at -31)
* CRBWDL12 (BLOD64B at -44)

### plutonia.wad

The new textures don't contain negative offsets, however it still has the doom2.wad negative offests.

### hexen.wad `TEXTURE1` entries

Not fixed in this PR since I didn't see a `gamemodeinfo_t` struct for Hexen in d_gi.cpp.

* D_AXE (W_103 at -1), used on MAP23

### heretic.wad

> I haven't yet checked if Heretic's IWAD also has textures containing negative y-offset patches.

## Other source ports with the same issue

* The same behavior is shown in ZDoom (starting from which version?), GZDoom, and Zandronium. They only backfill hardcoded fixes for `SKY1` and `BIGDOOR7`.
* Odamex and ZDaemon do not allow negative offsets, they're good.