### PR TITLE
fix `main_trantable` not initialized when drawing sky columns (causes…

### DIFF
--- a/source/r_plane.cpp
+++ b/source/r_plane.cpp
@@ -1036,6 +1036,9 @@ static void R_drawSky(angle_t viewangle, const visplane_t *pl, const skyflat_t *
    R_ColumnFunc colfunc = tilevert ? r_column_engine->DrawColumn :
                                      r_column_engine->DrawSkyColumn;
 
+   if (!main_tranmap)
+      R_InitTranMap(false);
+
    // killough 10/98: Use sky scrolling offset, and possibly flip picture
    for(int x = pl->minx; x <= pl->maxx; x++)
    {


### PR DESCRIPTION
… nullptr crash)