### PR TITLE
Fix crashes on exit (ENDOOM on Linux, quit while already on the quit menu)

### DIFF
--- a/source/Win32/i_w32main.cpp
+++ b/source/Win32/i_w32main.cpp
@@ -36,11 +36,11 @@
 #include "SDL_syswm.h"
 
 #include "../d_keywds.h"
+#include "../i_system.h"
 
 extern void I_W32InitExceptionHandler(void);
 extern int __cdecl I_W32ExceptionHandler(PEXCEPTION_POINTERS ep);
 extern int common_main(int argc, char **argv);
-extern void I_FatalError(int code, E_FORMAT_STRING(const char *error), ...) E_PRINTF(2, 3);
 
 int disable_sysmenu;
 
@@ -72,7 +72,7 @@ static void I_tweakConsole()
    {
       HMENU hMenu = GetSystemMenu(hwnd, FALSE);
       EnableMenuItem(hMenu, SC_CLOSE, MF_DISABLED|MF_GRAYED);
-      atexit(I_untweakConsole);
+      I_AtExit(I_untweakConsole);
    }
    SetConsoleTitle("Eternity Engine System Console");
 #endif

--- a/source/d_event.h
+++ b/source/d_event.h
@@ -38,7 +38,11 @@ enum evtype_t : int
    ev_keyup,
    ev_mouse,
    ev_joystick,
-   ev_text
+   ev_text,
+
+   // Quit event. Triggered when the user clicks the "close" button
+   // to terminate the application.
+   ev_quit,
 };
 
 // Event structure.

--- a/source/d_main.cpp
+++ b/source/d_main.cpp
@@ -1281,7 +1281,7 @@ static void D_DoomInit()
 
    startupmsg("Z_Init", "Init zone memory allocation daemon.");
    Z_Init();
-   atexit(I_Quit);
+   I_AtExit(I_Quit);
 
    FindResponseFile(); // Append response file arguments to command-line
 

--- a/source/d_net.cpp
+++ b/source/d_net.cpp
@@ -548,7 +548,7 @@ void D_CheckNetGame()
    D_InitPlayers();      
    
    C_NetInit();
-   atexit(D_QuitNetGame);       // killough
+   I_AtExit(D_QuitNetGame);       // killough
 }
 
 void D_InitNetGame()

--- a/source/g_cmd.cpp
+++ b/source/g_cmd.cpp
@@ -134,7 +134,7 @@ static void G_QuitDoom()
       i_haltimer.Sleep(1500);
    }
 
-   exit(0);
+   I_Exit(0);
 }
 
 CONSOLE_COMMAND(quit, 0)

--- a/source/g_demolog.cpp
+++ b/source/g_demolog.cpp
@@ -28,6 +28,7 @@
 #include "g_demolog.h"
 #include "m_argv.h"
 #include "m_qstr.h"
+#include "i_system.h"
 
 FILE *demoLogFile;
 
@@ -61,7 +62,7 @@ void G_DemoLogInit(const char *path)
       fprintf(demoLogFile, "%s ", argstring.constPtr());
    }
    fprintf(demoLogFile, "\n");
-   atexit(G_demoLogAtExit);
+   I_AtExit(G_demoLogAtExit);
 }
 
 //

--- a/source/hal/i_video.cpp
+++ b/source/hal/i_video.cpp
@@ -614,7 +614,7 @@ void I_InitGraphics()
    // enter graphics mode
    //
    
-   atexit(I_ShutdownGraphics);
+   I_AtExit(I_ShutdownGraphics);
    
    I_SetMode();
    

--- a/source/i_system.h
+++ b/source/i_system.h
@@ -35,6 +35,12 @@ struct SDL_Window;
 
 using i_errhandler_t = void (*)(char *errmsg);
 
+typedef void (*atexit_func_t)(void);
+// Schedule a function to be called when the program exits.
+void I_AtExit(atexit_func_t func);
+
+void I_Exit(int status);
+
 // Called by DoomMain.
 void I_Init();
 

--- a/source/mn_engin.cpp
+++ b/source/mn_engin.cpp
@@ -775,6 +775,8 @@ qstring &MN_GetInputBuffer()
    return input_buffer;
 }
 
+extern void MN_QuitDoom();
+
 //
 // MN_Responder
 //
@@ -791,6 +793,17 @@ bool MN_Responder(event_t *ev)
    static unsigned lastacceptedtime = 0;
 
    memset(tempstr, 0, sizeof(tempstr));
+
+   // "close" button pressed on window?
+   if (ev->type == ev_quit)
+   {
+      // give the quit menu widget a chance to interpret this as a confirmation
+      if(current_menuwidget && current_menuwidget->responder(ev, ka_nothing))
+         return true;
+
+      MN_QuitDoom();
+      return true;
+   }
 
    // haleyjd 07/03/04: call G_KeyResponder with kac_menu to filter
    // for menu-class actions

--- a/source/mn_misc.cpp
+++ b/source/mn_misc.cpp
@@ -153,11 +153,15 @@ static bool MN_PopupResponder(event_t *ev, int action)
    int *menuSounds = GameModeInfo->menuSounds;
    char ch;
    
-   if(ev->type != ev_keydown && ev->type != ev_text)
+   if(ev->type != ev_keydown && ev->type != ev_text && ev->type != ev_quit)
       return false;
 
    if(ev->type == ev_text)
       ch = ectype::toLower(ev->data1);
+   else if (ev->type == ev_quit && menuactive &&
+            popup_message_type == popup_question &&
+            !strcmp(popup_message_command, "quit"))
+      ch = 'y';
    else if(!ectype::isPrint(ev->data1))
       ch = ev->data1;
    else

--- a/source/p_hubs.cpp
+++ b/source/p_hubs.cpp
@@ -108,7 +108,7 @@ static void P_ClearHubsAtExit(void)
    
    if(atexit_set) return;   // already set
    
-   atexit(P_ClearHubs);
+   I_AtExit(P_ClearHubs);
    
    atexit_set = true;
 }

--- a/source/sdl/i_input.cpp
+++ b/source/sdl/i_input.cpp
@@ -313,7 +313,6 @@ void I_StartFrame()
 // Mouse
 //
 
-extern void MN_QuitDoom();
 extern acceltype_e mouseAccel_type;
 extern int mouseAccel_threshold;
 extern double mouseAccel_value;
@@ -730,7 +729,10 @@ static void I_getEvent(SDL_Window *window)
          break;
       }
       case SDL_QUIT:
-         MN_QuitDoom();
+         {
+            static const event_t event_quit = { ev_quit };
+            D_PostEvent(&event_quit);
+         }
          break;
 
       case SDL_WINDOWEVENT:

--- a/source/sdl/i_net.cpp
+++ b/source/sdl/i_net.cpp
@@ -504,7 +504,7 @@ void I_InitNetwork(void)
    
    SDLNet_Init();
    
-   atexit(I_QuitNetwork);
+   I_AtExit(I_QuitNetwork);
    
    i++;
    while(++i < myargc && myargv[i][0] != '-')

--- a/source/sdl/i_sdlmusic.cpp
+++ b/source/sdl/i_sdlmusic.cpp
@@ -337,7 +337,7 @@ static int I_SDLInitMusic(void)
    if(!snd_init)
    {
       if((success = I_SDLInitSoundForMusic()))
-         atexit(I_SDLShutdownSoundForMusic);
+         I_AtExit(I_SDLShutdownSoundForMusic);
    }
    else
       success = 1;

--- a/source/sdl/i_sound.cpp
+++ b/source/sdl/i_sound.cpp
@@ -227,7 +227,7 @@ void I_InitSound(void)
          i_sounddriver = &i_sdlsound_driver;
          if(i_sounddriver->InitSound())
          {
-            atexit(I_ShutdownSound);  
+            I_AtExit(I_ShutdownSound);
             snd_init = true;
          }
          break;
@@ -236,7 +236,7 @@ void I_InitSound(void)
          i_sounddriver = &i_pcsound_driver;
          if(i_sounddriver->InitSound())
          {
-            atexit(I_ShutdownSound);
+            I_AtExit(I_ShutdownSound);
             snd_init = true;
          }
          break;
@@ -291,7 +291,7 @@ void I_InitMusic(void)
       i_musicdriver = &i_sdlmusicdriver;
       if(i_musicdriver->InitMusic())
       {
-         atexit(I_ShutdownMusic);
+         I_AtExit(I_ShutdownMusic);
          mus_init = true;
       }
       break;

--- a/source/sdl/i_system.cpp
+++ b/source/sdl/i_system.cpp
@@ -176,9 +176,6 @@ void I_Quit(void)
    // sf : rearrange this so the errmsg doesn't get messed up
    if(error_exitcode >= I_ERRORLEVEL_MESSAGE)
       puts(errmsg);   // killough 8/8/98
-
-   // FIXME: TEMPORARILY disabled on MacOS because of some crash in SDL_Renderer
-   // affecting functions. MUST FIX.
    else if(!speedyexit) // MaxW: The user didn't Alt+F4
       I_EndDoom();
 

--- a/source/sdl/i_system.cpp
+++ b/source/sdl/i_system.cpp
@@ -55,6 +55,44 @@
 extern int waitAtExit;
 #endif
 
+struct atexit_listentry_t
+{
+   atexit_func_t func;
+   atexit_listentry_t *next;
+};
+
+static atexit_listentry_t *exit_funcs = NULL;
+
+void I_AtExit(atexit_func_t func)
+{
+   atexit_listentry_t *entry;
+
+   entry = (atexit_listentry_t *)malloc(sizeof(*entry));
+
+   entry->func = func;
+   entry->next = exit_funcs;
+   exit_funcs = entry;
+}
+
+void I_Exit(int status)
+{
+   atexit_listentry_t *entry, *next;
+
+   // Run through all exit functions
+
+   entry = exit_funcs;
+
+   while (entry != NULL)
+   {
+      entry->func();
+      next = entry->next;
+      free(entry);
+      entry = next;
+   }
+
+   exit(status);
+}
+
 //
 // I_BaseTiccmd
 //
@@ -90,7 +128,7 @@ void I_Init()
    // haleyjd 04/15/02: initialize joystick
    I_InitGamePads(MN_UpdateGamepadMenus);
  
-   atexit(I_Shutdown);
+   I_AtExit(I_Shutdown);
    
    // killough 2/21/98: avoid sound initialization if no sound & no music
    extern bool nomusicparm, nosfxparm;
@@ -179,7 +217,7 @@ void I_QuitFast()
 {
    puts("Eternity quit quickly.");
    speedyexit = true;
-   exit(0);
+   I_Exit(0);
 }
 
 //
@@ -246,7 +284,7 @@ void I_ExitWithMessage(E_FORMAT_STRING(const char *msg), ...)
    if(!has_exited)       // If it hasn't exited yet, exit now -- killough
    {
       has_exited = true; // Prevent infinitely recursive exits -- killough
-      exit(0);
+      I_Exit(0);
    }
 }
 

--- a/source/z_native.cpp
+++ b/source/z_native.cpp
@@ -294,7 +294,7 @@ static void Z_Close()
 
 void Z_Init()
 {
-   atexit(Z_Close);            // exit handler
+   I_AtExit(Z_Close);            // exit handler
 
    Z_LogPrintf("Initialized zone heap (using native implementation)\n");
 }


### PR DESCRIPTION
Fix two crash issues on exit:

* One is a crash on exit related to ENDOOM (issue #583, maybe also related to issue #302 though that appears to have fixed itself on its own).

  The problem is that rendering ENDOOM inside C's standard `atexit` is problematic, because various Linux libraries e.g. [Mesa](https://en.wikipedia.org/wiki/Mesa_(computer_graphics)) also [use it to shut themselves down on `atexit`](https://gitlab.freedesktop.org/search?search=atexit%28&nav_source=navbar&project_id=176&group_id=1155&search_code=true&repository_ref=main), so when our handlers run, they can't be used anymore.

  This only reproduces with some graphics drivers on Linux. For example on my Arch Linux system, it crashes with a Ryzen 5700G APU, but it works fine with an Intel i5-7200U iGPU.

  To fix it, we [borrow an `atexit` clone from Chocolate Doom](https://github.com/chocolate-doom/chocolate-doom/commit/3a41ade9fab0556d0d025c0b0e81834436a4f2e8), so that we can run all our handlers first, before the ones registered with the C's standard `atexit` run.

* Another fix for a crash that happens if you are in the confirm quit menu, and you try to quit again (i.e. try to close the Eternity window again, or do anything that generates a `SDL_QUIT` event).
