### PR TITLE
ACS void SetPolyobjXY(int po, fixed x, fixed y)

### DIFF
--- a/source/acs_func.cpp
+++ b/source/acs_func.cpp
@@ -1064,6 +1064,25 @@ bool ACS_CF_GetPolyobjY(ACS_CF_ARGS)
 }
 
 //
+// ACS_CF_SetPolyobjXY
+//
+// void SetPolyobjXY(int po, fixed x, fixed y);
+//
+bool ACS_CF_SetPolyobjXY(ACS_CF_ARGS)
+{
+   polyobj_t* po = Polyobj_GetForNum(argV[0]);
+   fixed_t x = argV[1];
+   fixed_t y = argV[2];
+
+   if (po)
+      Polyobj_MoveToXY(po, x, y);
+
+   thread->dataStk.push(0);
+
+   return false;
+}
+
+//
 // ACS_CF_GetScreenH
 //
 // int GetScreenHeight(void);

--- a/source/acs_intr.cpp
+++ b/source/acs_intr.cpp
@@ -373,6 +373,7 @@ ACSEnvironment::ACSEnvironment() :
    addFuncDataACS0(300, addCallFunc(ACS_CF_GetLineX));
    addFuncDataACS0(301, addCallFunc(ACS_CF_GetLineY));
    addFuncDataACS0(302, addCallFunc(ACS_CF_SetAirFriction));
+   addFuncDataACS0(303, addCallFunc(ACS_CF_SetPolyobjXY));
 }
 
 //

--- a/source/acs_intr.h
+++ b/source/acs_intr.h
@@ -359,6 +359,7 @@ bool ACS_CF_GetLineY(ACS_CF_ARGS);
 bool ACS_CF_GetPlayerInput(ACS_CF_ARGS);
 bool ACS_CF_GetPolyobjX(ACS_CF_ARGS);
 bool ACS_CF_GetPolyobjY(ACS_CF_ARGS);
+bool ACS_CF_SetPolyobjXY(ACS_CF_ARGS);
 bool ACS_CF_GetScreenH(ACS_CF_ARGS);
 bool ACS_CF_GetScreenW(ACS_CF_ARGS);
 bool ACS_CF_GetSectorCeilingZ(ACS_CF_ARGS);

--- a/source/polyobj.cpp
+++ b/source/polyobj.cpp
@@ -1239,6 +1239,76 @@ static bool Polyobj_moveXY(polyobj_t *po, fixed_t x, fixed_t y, bool onload = fa
 }
 
 //
+// Polyobj_moveToXY
+//
+// Moves a polyobject to a specfic position
+//
+void Polyobj_MoveToXY(polyobj_t* po, fixed_t x, fixed_t y)
+{
+   vertex_t  dist, dest;
+   int i;
+
+   // don't move any bad polyobject that may have gotten through
+   if (po->flags & POF_ISBAD)
+      return;
+
+   dest.x = x;
+   dest.y = y;
+
+   // calculate distance from centerPt to destination
+   // ioanch 20151218: use 32-bit coordinates
+   dist.x = po->centerPt.x - dest.x;
+   dist.y = po->centerPt.y - dest.y;
+
+   // update linedef bounding boxes
+   for (i = 0; i < po->numLines; ++i)
+   {
+      Mobj* mo;
+
+      Polyobj_bboxSub(po->lines[i]->bbox, &dist);
+
+      // 05/25/08: must change lines' sector groupids for correct portal
+      // automap overlay behavior.
+      mo = po->spawnSpotMobj;
+      po->lines[i]->frontsector->groupid = mo->subsector->sector->groupid;
+      po->lines[i]->soundorg.groupid = mo->subsector->sector->groupid;
+   }
+
+   // ioanch 20160226: update portal position
+   Polyobj_collectPortals(po);
+   Polyobj_moveLinkedPortals(po, -dist.x, -dist.y, false);
+
+   // translate vertices and record original coordinates relative to spawn spot
+   for (i = 0; i < po->numVertices; ++i)
+   {
+      Polyobj_vecSub(po->vertices[i], &dist);
+      po->tmpVerts[i] = *po->vertices[i]; // backup position
+      Polyobj_vecSub2(&(po->origVerts[i]), po->vertices[i], &dest);
+   }
+
+   po->spawnSpot.x = dest.x;
+   po->spawnSpot.y = dest.y;
+
+   // Update sound origins
+   for (i = 0; i < po->numLines; ++i)
+   {
+      line_t& line = *po->lines[i];
+      line.soundorg.x = line.v1->x + line.dx / 2;
+      line.soundorg.y = line.v1->y + line.dy / 2;
+
+      Polyobj_relinkLine(line);
+   }
+
+   Polyobj_removeFromBlockmap(po); // unlink it from the blockmap
+   R_DetachPolyObject(po);
+   Polyobj_linkToBlockmap(po);     // relink to blockmap
+   Polyobj_setCenterPt(po);
+   R_AttachPolyObject(po);
+
+   Polyobj_updateAnchoredPortals(*po); // finally update the anchored portals.
+}
+
+//
 // Polyobj_rotatePoint
 //
 // Rotates a point and then translates it relative to point c.

--- a/source/polyobj.h
+++ b/source/polyobj.h
@@ -298,6 +298,7 @@ polyobj_t *Polyobj_GetForNum(int id);
 bool Polyobj_IsSpawnSpot(const Mobj &mo);
 void Polyobj_InitLevel(void);
 void Polyobj_MoveOnLoad(polyobj_t *po, angle_t angle, fixed_t x, fixed_t y);
+void Polyobj_MoveToXY(polyobj_t* po, fixed_t x, fixed_t y);
 
 int EV_DoPolyDoor(const polydoordata_t *);
 int EV_DoPolyObjMove(const polymovedata_t *);


### PR DESCRIPTION
Sets a polyobject to the absolute coordinates indicated. Intentionally skips interpolation and collision checks.