### PR TITLE
Widescreen asset support for Doom

### DIFF
--- a/source/d_main.cpp
+++ b/source/d_main.cpp
@@ -258,7 +258,7 @@ static void D_PageDrawer()
    if(pagename && (l = W_CheckNumForName(pagename)) != -1)
    {
       // haleyjd 08/15/02: handle Heretic pages
-      V_DrawFSBackground(&subscreen43, l);
+      V_DrawFSBackground(&vbscreenyscaled, l);
 
       if(GameModeInfo->flags & GIF_HASADVISORY && demosequence == 1)
       {

--- a/source/f_finale.cpp
+++ b/source/f_finale.cpp
@@ -304,7 +304,7 @@ static void F_TextWrite()
    // killough 11/98: the background-filling code was already in m_menu.c
    lumpnum = wGlobalDir.checkNumForNameNSG(LevelInfo.backDrop, lumpinfo_t::ns_flats);
    if(lumpnum > 0)
-      V_DrawFSBackground(&subscreen43, lumpnum);
+      V_DrawFSBackground(&vbscreenyscaled, lumpnum);
 
    // draw some of the text onto the screen
    cx = GameModeInfo->fTextPos->x;
@@ -673,11 +673,19 @@ static void F_BunnyScroll()
       scrolled = 0;
               
    // ANYRES
+   int ws_offset2;
+   // Doom I Enhanced screens
+   if (p1->width == 426 && p2->width == 320)
+      ws_offset2 = 106;
+   else
+      ws_offset2 = (vbscreenyscaled.unscaledw - p2->width) / 2;
+   int ws_offset1 = (vbscreenyscaled.unscaledw - p1->width) / 2;
    if(scrolled > 0)
-      V_DrawPatchGeneral(320 - scrolled, 0, &subscreen43, p2, false);
-   if(scrolled < 320)
-      V_DrawPatchGeneral(-scrolled, 0, &subscreen43, p1, false);
-      
+      V_DrawPatchGeneral(320 - scrolled + ws_offset2, 0, &vbscreenyscaled, p2, false);
+   if(scrolled < 320 || ws_offset2 > 0)
+      V_DrawPatchGeneral(-scrolled + ws_offset1, 0, &vbscreenyscaled, p1, false);
+   if(ws_offset2 > 0)
+      D_DrawWings();
    if(finalecount < 1130)
       return;
    if(finalecount < 1180)
@@ -831,18 +839,18 @@ static void F_FinaleEndDrawer()
    switch(finaletype)
    {
    case FINALE_DOOM_CREDITS:
-      V_DrawPatch(0, 0, &subscreen43, 
+      V_DrawPatchFS(&vbscreenyscaled,
          PatchLoader::CacheName(wGlobalDir, sw ? "HELP2" : "CREDIT", PU_CACHE));
       break;
    case FINALE_DOOM_DEIMOS:
-      V_DrawPatch(0,0,&subscreen43, 
+      V_DrawPatchFS(&vbscreenyscaled, 
          PatchLoader::CacheName(wGlobalDir, "VICTORY2",PU_CACHE));
       break;
    case FINALE_DOOM_BUNNY:
       F_BunnyScroll();
       break;
    case FINALE_DOOM_MARINE:
-      V_DrawPatch(0,0,&subscreen43,
+      V_DrawPatchFS(&vbscreenyscaled,
          PatchLoader::CacheName(wGlobalDir, "ENDPIC", PU_CACHE));
       break;
    case FINALE_HTIC_CREDITS:

--- a/source/mn_engin.cpp
+++ b/source/mn_engin.cpp
@@ -482,7 +482,7 @@ void MN_DrawMenu(menu_t *menu)
    {
       // haleyjd 04/04/10: draw menus higher in some game modes
       y -= GameModeInfo->menuOffset;
-      V_DrawBackground(mn_background_flat, &vbscreen);
+      V_DrawBackground(mn_background_flat, &vbscreenyscaled);
    }
 
    // haleyjd: calculate widest width for LALIGNED flag

--- a/source/mn_misc.cpp
+++ b/source/mn_misc.cpp
@@ -565,7 +565,7 @@ static void MN_HelpDrawer()
       D_DrawPillars();
 
       // haleyjd 05/18/09: use smart background drawer
-      V_DrawFSBackground(&subscreen43, lumpnum);
+      V_DrawFSBackground(&vbscreenyscaled, lumpnum);
    }
 }
 

--- a/source/st_stuff.cpp
+++ b/source/st_stuff.cpp
@@ -408,7 +408,7 @@ static void ST_refreshBackground()
       // haleyjd 01/12/04: changed translation handling
       if(GameType != gt_single)
       {
-         V_DrawPatchTranslated(ST_FX, ST_FY, &subscreen43, faceback,
+         V_DrawPatchTranslated(ST_FX, ST_FY, &vbscreenyscaled, faceback,
             plyr->colormap ?
                translationtables[(plyr->colormap - 1)] :
                nullptr, 

--- a/source/v_video.cpp
+++ b/source/v_video.cpp
@@ -35,6 +35,7 @@
 #include "m_bbox.h"
 #include "r_draw.h"
 #include "r_main.h"
+#include "r_patch.h"
 #include "v_block.h"
 #include "v_misc.h"
 #include "v_patchfmt.h"
@@ -680,9 +681,10 @@ void V_DrawBlockFS(VBuffer *buffer, const byte *src)
 // haleyjd 05/18/09: Convenience routine to do V_DrawPatch but with
 // the assumption that the graphic is fullscreen, 320x200.
 //
+// If wider than the screen, center align.
 void V_DrawPatchFS(VBuffer *buffer, patch_t *patch)
 {
-   V_DrawPatchGeneral(0, 0, buffer, patch, false);
+   V_DrawPatchGeneral((buffer->unscaledw - patch->width) / 2, 0, buffer, patch, false);
 }
 
 //

--- a/source/wi_stuff.cpp
+++ b/source/wi_stuff.cpp
@@ -757,7 +757,8 @@ static void WI_drawAnimatedBack()
       a = &anims[epsd][i];
       
       if(a->ctr >= 0)
-         V_DrawPatch(a->loc.x, a->loc.y, &subscreen43, a->p[a->ctr]);
+         //widescreen alignment
+         V_DrawPatch(a->loc.x + (vbscreenyscaled.unscaledw - SCREENWIDTH) / 2, a->loc.y, &vbscreenyscaled, a->p[a->ctr]);
    }
 }
 
@@ -1957,7 +1958,7 @@ static void WI_DrawBackground()
       snprintf(name, sizeof(name), "WIMAP%d", epsd);
 
    // background
-   V_DrawFSBackground(&subscreen43, wGlobalDir.checkNumForName(name));
+   V_DrawFSBackground(&vbscreenyscaled, wGlobalDir.checkNumForName(name));
 
    // re-fade if we were called due to video mode reset
    if(fade_applied && wi_fade_color != -1)


### PR DESCRIPTION
Taking a stab at #500.

The differences in scaling caused a slight misalignment on the intermission map animations, so they are drawn to `vbscreenyscaled` as well.