### PR TITLE
Widescreen asset support for Heretic

### DIFF
--- a/source/d_main.cpp
+++ b/source/d_main.cpp
@@ -516,31 +516,10 @@ static void D_showMemStats()
 #endif
 
 //
-// D_DrawPillars
-//
-// Will draw pillars for pillarboxing the 4:3 subscreen.
-//
-void D_DrawPillars()
-{
-   int wingwidth;
-   
-   if(vbscreen.getVirtualAspectRatio() <= 4 * FRACUNIT / 3)
-      return;
-   
-   wingwidth = (vbscreen.width - (vbscreen.height * 4 / 3)) / 2;
-   if(wingwidth <= 0)
-         return;
-
-   V_ColorBlock(&vbscreen, GameModeInfo->blackIndex, 0, 0, wingwidth, vbscreen.height);
-   V_ColorBlock(&vbscreen, GameModeInfo->blackIndex, vbscreen.width - wingwidth,
-                0, wingwidth, vbscreen.height);
-}
-
-//
 // D_DrawWings
 //
-// haleyjd: Draw pillarboxing during non-play gamestates, or the wings of the 
-// status bar while it is visible. This is necessary when drawing patches at
+// haleyjd: Draw wings of the status bar while it is visible.
+// This is necessary when drawing patches at
 // 4:3 aspect ratio over widescreen video modes.
 //
 void D_DrawWings()
@@ -556,25 +535,17 @@ void D_DrawWings()
    if(wingwidth <= 0)
       return;
 
-   if(gamestate == GS_LEVEL && !MN_CheckFullScreen())
+   if(gamestate == GS_LEVEL && !MN_CheckFullScreen() &&
+      (scaledwindow.height != SCREENHEIGHT || (automapactive && !automap_overlay)))
    {
-      if(scaledwindow.height != SCREENHEIGHT || (automapactive && !automap_overlay))
-      {
-         unsigned int bottom   = SCREENHEIGHT - 1;
-         unsigned int statbarh = static_cast<unsigned int>(GameModeInfo->StatusBar->height);
-         
-         int ycoord      = vbscreen.y1lookup[bottom - statbarh];
-         int blockheight = vbscreen.y2lookup[bottom] - ycoord + 1;
+      unsigned int bottom   = SCREENHEIGHT - 1;
+      unsigned int statbarh = static_cast<unsigned int>(GameModeInfo->StatusBar->height);
+      
+      int ycoord      = vbscreen.y1lookup[bottom - statbarh];
+      int blockheight = vbscreen.y2lookup[bottom] - ycoord + 1;
 
-         R_VideoEraseScaled(0, ycoord, wingwidth, blockheight);
-         R_VideoEraseScaled(vbscreen.width - wingwidth, ycoord, wingwidth, blockheight);
-      }
-   }
-   else
-   {
-      V_ColorBlock(&vbscreen, GameModeInfo->blackIndex, 0, 0, wingwidth, vbscreen.height);
-      V_ColorBlock(&vbscreen, GameModeInfo->blackIndex, vbscreen.width - wingwidth,
-                   0, wingwidth, vbscreen.height);
+      R_VideoEraseScaled(0, ycoord, wingwidth, blockheight);
+      R_VideoEraseScaled(vbscreen.width - wingwidth, ycoord, wingwidth, blockheight);
    }
 }
 

--- a/source/d_main.h
+++ b/source/d_main.h
@@ -65,7 +65,6 @@ extern camera_t *camera;
 //
 
 void D_PageTicker();
-void D_DrawPillars();
 void D_DrawWings();
 void D_AdvanceDemo();
 void D_StartTitle();

--- a/source/f_finale.cpp
+++ b/source/f_finale.cpp
@@ -613,7 +613,7 @@ static void F_CastDrawer()
    
    // erase the entire screen to a background
    // Ty 03/30/98 bg texture extern
-   V_DrawFSBackground(&subscreen43, wGlobalDir.checkNumForName(DEH_String("BGCASTCALL")));
+   V_DrawFSBackground(&vbscreenyscaled, wGlobalDir.checkNumForName(DEH_String("BGCASTCALL")));
    
    F_CastTitle();
 
@@ -685,7 +685,7 @@ static void F_BunnyScroll()
    if(scrolled < 320 || ws_offset2 > 0)
       V_DrawPatchGeneral(-scrolled + ws_offset1, 0, &vbscreenyscaled, p1, false);
    if(ws_offset2 > 0)
-      D_DrawWings();
+      V_DrawPillars();
    if(finalecount < 1130)
       return;
    if(finalecount < 1180)
@@ -726,7 +726,7 @@ static void F_DrawUnderwater()
          palette = (byte *)wGlobalDir.cacheLumpName("E2PAL", PU_CACHE);
          I_SetPalette(palette);
 
-         V_DrawBlock(0,0,&subscreen43,SCREENWIDTH,SCREENHEIGHT,
+         V_DrawBlockFS(&vbscreenyscaled,
                      (byte *)wGlobalDir.cacheLumpName("E2END", PU_CACHE));
          finalestage = 3;
       }
@@ -739,7 +739,7 @@ static void F_DrawUnderwater()
    
    case 4:
       Console.enabled = true;
-      V_DrawBlock(0,0,&subscreen43,SCREENWIDTH,SCREENHEIGHT,
+      V_DrawBlockFS(&vbscreenyscaled,
                   (byte *)wGlobalDir.cacheLumpName("TITLE", PU_CACHE));
       break;
    }
@@ -854,8 +854,8 @@ static void F_FinaleEndDrawer()
          PatchLoader::CacheName(wGlobalDir, "ENDPIC", PU_CACHE));
       break;
    case FINALE_HTIC_CREDITS:
-      V_DrawBlock(0, 0, &subscreen43, SCREENWIDTH, SCREENHEIGHT,
-                  (byte *)wGlobalDir.cacheLumpName(sw ? "ORDER" : "CREDIT", PU_CACHE));
+      V_DrawBlockFS(&vbscreenyscaled,
+         (byte *)wGlobalDir.cacheLumpName(sw ? "ORDER" : "CREDIT", PU_CACHE));
       break;
    case FINALE_HTIC_WATER:
       F_DrawUnderwater();
@@ -864,8 +864,8 @@ static void F_FinaleEndDrawer()
       F_DemonScroll();
       break;
    case FINALE_END_PIC:
-      V_DrawPatch(0, 0, &subscreen43,
-                  PatchLoader::CacheName(wGlobalDir, LevelInfo.endPic, PU_CACHE));
+      V_DrawPatchFS(&vbscreenyscaled,
+          PatchLoader::CacheName(wGlobalDir, LevelInfo.endPic, PU_CACHE));
       break;
    default: // ?
       break;

--- a/source/hi_stuff.cpp
+++ b/source/hi_stuff.cpp
@@ -988,26 +988,26 @@ static void HI_DrawBackground(void)
    {
       case INTR_LEAVING:
          if(hi_exitpic)
-            V_DrawPatch(0, 0, &subscreen43, hi_exitpic);
+            V_DrawPatchFS(&vbscreenyscaled, hi_exitpic);
          else
-            V_DrawBackground("FLOOR16", &subscreen43);
+            V_DrawBackground("FLOOR16", &vbscreenyscaled);
          break;
       case INTR_GOING:
       case INTR_WAITING:
          // Make sure to continue showing the last explicit exit pic if the next enterpic is not
          // provided
          if(estrnonempty(hi_wbs.li_lastexitpic) && estrempty(hi_wbs.li_nextenterpic))
-            V_DrawPatch(0, 0, &subscreen43, hi_exitpic);
+            V_DrawPatchFS(&vbscreenyscaled, hi_exitpic);
          else if(hi_interpic)
-            V_DrawPatch(0, 0, &subscreen43, hi_interpic);
+            V_DrawPatchFS(&vbscreenyscaled, hi_interpic);
          else
-            V_DrawBackground("FLOOR16", &subscreen43);
+            V_DrawBackground("FLOOR16", &vbscreenyscaled);
          break;
       default:
          if(estrnonempty(hi_wbs.li_lastexitpic) && estrempty(hi_wbs.li_nextenterpic))
-            V_DrawPatch(0, 0, &subscreen43, hi_exitpic);
+            V_DrawPatchFS(&vbscreenyscaled, hi_exitpic);
          else
-            V_DrawBackground("FLOOR16", &subscreen43);
+            V_DrawBackground("FLOOR16", &vbscreenyscaled);
          break;
    }
 }

--- a/source/mn_misc.cpp
+++ b/source/mn_misc.cpp
@@ -559,11 +559,6 @@ static void MN_HelpDrawer()
       // haleyjd: support raw lumps
       int lumpnum = helpscreens[viewing_helpscreen].lumpnum;
 
-      // if the screen is larger than 4:3, we need to draw pillars ourselves,
-      // as D_Display won't be able to know if this widget is fullscreen or not
-      // in time to do it as usual.
-      D_DrawPillars();
-
       // haleyjd 05/18/09: use smart background drawer
       V_DrawFSBackground(&vbscreenyscaled, lumpnum);
    }

--- a/source/v_video.cpp
+++ b/source/v_video.cpp
@@ -665,14 +665,38 @@ void V_DrawMaskedBlockTR(int x, int y, VBuffer *buffer, int width, int height,
 }
 
 //
+   // V_DrawPillars
+//
+// Will draw pillars for pillarboxing the 4:3 subscreen.
+//
+void V_DrawPillars()
+{
+   int wingwidth;
+
+   if (vbscreen.getVirtualAspectRatio() <= 4 * FRACUNIT / 3)
+      return;
+
+   wingwidth = (vbscreen.width - (vbscreen.height * 4 / 3)) / 2;
+   if (wingwidth <= 0)
+      return;
+
+   V_ColorBlock(&vbscreen, GameModeInfo->blackIndex, 0, 0, wingwidth, vbscreen.height);
+   V_ColorBlock(&vbscreen, GameModeInfo->blackIndex, vbscreen.width - wingwidth,
+      0, wingwidth, vbscreen.height);
+}
+
+//
 // V_DrawBlockFS
 //
 // haleyjd 05/18/09: Convenience routine to do V_DrawBlock but with
 // the assumption that the graphic is fullscreen, 320x200.
 //
+// If drawing to widescreen, center align.
 void V_DrawBlockFS(VBuffer *buffer, const byte *src)
 {
-   buffer->BlockDrawer(0, 0, buffer, SCREENWIDTH, SCREENHEIGHT, src);
+   V_DrawPillars();
+
+   buffer->BlockDrawer((buffer->unscaledw - SCREENWIDTH) / 2, 0, buffer, SCREENWIDTH, SCREENHEIGHT, src);
 }
 
 //
@@ -681,9 +705,11 @@ void V_DrawBlockFS(VBuffer *buffer, const byte *src)
 // haleyjd 05/18/09: Convenience routine to do V_DrawPatch but with
 // the assumption that the graphic is fullscreen, 320x200.
 //
-// If wider than the screen, center align.
+// If drawing to widescreen, center align.
 void V_DrawPatchFS(VBuffer *buffer, patch_t *patch)
 {
+   V_DrawPillars();
+
    V_DrawPatchGeneral((buffer->unscaledw - patch->width) / 2, 0, buffer, patch, false);
 }
 

--- a/source/v_video.h
+++ b/source/v_video.h
@@ -195,6 +195,7 @@ void V_DrawMaskedBlockTR(int x, int y, VBuffer *buffer, int width, int height,
 void V_DrawBlockFS(VBuffer *buffer, const byte *src);
 void V_DrawPatchFS(VBuffer *buffer, patch_t *patch);
 void V_DrawFSBackground(VBuffer *dest, int lumpnum);
+void V_DrawPillars();
 
 // V_FindBestColor (haleyjd)
 // A function that requantizes a color into the default game palette


### PR DESCRIPTION
Continuing #500.

Added support for Heretic, fixed some minor issues.

Split off `DrawPillars()` functionality completely from `DrawWings()` and into the background drawing routines themselves. Calling it straight from `D_Display()` sometimes made the pillars cover up the widescreen background during wipes.