### PR TITLE
make SECF_MONSTERDEATH kill the actual monster instead of trying to kill a null player

### DIFF
--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -1753,7 +1753,7 @@ void Mobj::Think()
          (flags & MF_SHOOTABLE) &&
          !(flags & MF_FLOAT))
       {
-         P_DamageMobj(player->mo, nullptr, nullptr, GOD_BREACH_DAMAGE, sector->damagemod);
+         P_DamageMobj(this, nullptr, nullptr, GOD_BREACH_DAMAGE, sector->damagemod);
          return;
       }
 


### PR DESCRIPTION
Fixes map32 of Eviternity II (rc5) and probably other stuff.