### PR TITLE
add patches/ as a recognized directory for zip archives

### DIFF
--- a/source/w_formats.cpp
+++ b/source/w_formats.cpp
@@ -246,12 +246,13 @@ static namespace_matcher_t matchers[] =
    { "translations/", lumpinfo_t::ns_translations }, // EE extension
    { "gamepads/",     lumpinfo_t::ns_pads         }, // EE extension
    { "textures/",     lumpinfo_t::ns_textures     },
+   { "patches/",      lumpinfo_t::ns_global       }, //Treated as global in EE as of 26/01/2024
+   // { "patches/",      lumpinfo_t::ns_patches      }, FIXME - as soon as VImage is done!
 
    { nullptr,         -1                          }  // keep this last
 
    // TODO ??
    /*
-   { "patches/",      lumpinfo_t::ns_patches      },
    { "voices/",       lumpinfo_t::ns_voices       },
    { "voxels/",       lumpinfo_t::ns_voxels       },
    */


### PR DESCRIPTION
Right now, the textures/ directory is only useful for single-texture lumps that would ordinarily be between TX_START and TX_END. The only option to use patch textures in a PKE is to place them into the archive root or into a folder that is added to the global namespace like graphics/ or music/. this pr adds patches/ as a global namespace directory.