### PR TITLE
add block comments to UMAPINFO parsing

### DIFF
--- a/source/xl_scripts.cpp
+++ b/source/xl_scripts.cpp
@@ -97,6 +97,11 @@ void XLTokenizer::doStateScan()
          state = STATE_COMMENT;
          break;
       }
+      else if(c == '/' && input[idx+1] == '*' && (flags & TF_BLOCKCOMMENTS))
+      {
+          state     = STATE_INBCOMMENT;
+          break;
+      }
       else if(c == '[' && (flags & TF_BRACKETS))
       {
          tokentype = TOKEN_BRACKETSTR;
@@ -146,12 +151,14 @@ void XLTokenizer::doStateInToken()
    default:
       if((c == '#' && flags & TF_HASHCOMMENTS) ||
          (c == '/' && input[idx+1] == '/' && flags & TF_SLASHCOMMENTS) ||
+         (c == '/' && input[idx+1] == '*' && flags & TF_BLOCKCOMMENTS) ||
          (flags & TF_OPERATORS && !token.empty() &&
           XL_isIdentifierChar(c) != XL_isIdentifierChar(token[0])) ||
          (c == '"' && tokentype == TOKEN_KEYWORD))
       {
          // hashes may conditionally be supported as comments
          // double slashes may conditionally be supported as comments
+         // block comments may be conditionally supported as comments
          // operators and identifiers are separate
          // starting strings next to keywords should be detected
          --idx;
@@ -312,6 +319,27 @@ void XLTokenizer::doStateComment()
    }
 }
 
+void XLTokenizer::doStateBlockComment()
+{
+    // consume all input until next '*/'
+    if(flags & TF_LINEBREAKS)
+    {
+       tokentype = TOKEN_LINEBREAK;
+       state     = STATE_DONE;
+    }
+    
+    if((input[idx] == '*' && input[idx+1] == '/'))
+    {
+        idx++; //push ahead then start to scan again
+        state = STATE_SCAN;
+    } 
+    else if(input[idx] == '\0') // end of input (technically malformed)
+    {
+       tokentype = TOKEN_EOF;
+       state     = STATE_DONE;
+    }
+}
+
 // State table for the tokenizer - static array of method pointers :)
 void (XLTokenizer::* XLTokenizer::States[])() =
 {
@@ -319,7 +347,8 @@ void (XLTokenizer::* XLTokenizer::States[])() =
    &XLTokenizer::doStateInToken,
    &XLTokenizer::doStateInBrackets,
    &XLTokenizer::doStateQuoted,
-   &XLTokenizer::doStateComment
+   &XLTokenizer::doStateComment,
+   &XLTokenizer::doStateBlockComment
 };
 
 //

--- a/source/xl_scripts.cpp
+++ b/source/xl_scripts.cpp
@@ -322,12 +322,6 @@ void XLTokenizer::doStateComment()
 void XLTokenizer::doStateBlockComment()
 {
     // consume all input until next '*/'
-    if(flags & TF_LINEBREAKS)
-    {
-       tokentype = TOKEN_LINEBREAK;
-       state     = STATE_DONE;
-    }
-    
     if((input[idx] == '*' && input[idx+1] == '/'))
     {
         idx++; //push ahead then start to scan again

--- a/source/xl_scripts.h
+++ b/source/xl_scripts.h
@@ -80,7 +80,7 @@ public:
       TF_OPERATORS     = 0x00000010, // C-style identifiers, no space operators
       TF_ESCAPESTRINGS = 0x00000020, // Add support for escaping strings
       TF_STRINGSQUOTED = 0x00000040, // Strings must be quoted, otherwise they're keywords
-      TF_BLOCKCOMMENTS = 0x00000080  // supports block comments with /* */
+      TF_BLOCKCOMMENTS = 0x00000080, // supports block comments with /* */
    };
 
 protected:

--- a/source/xl_scripts.h
+++ b/source/xl_scripts.h
@@ -53,6 +53,7 @@ public:
       STATE_INBRACKETS, // in a bracketed token
       STATE_QUOTED,     // in a quoted string
       STATE_COMMENT,    // reading out a comment (eat rest of line)
+      STATE_INBCOMMENT, // in a block comment
       STATE_DONE        // finished the current token
    };
 
@@ -79,6 +80,7 @@ public:
       TF_OPERATORS     = 0x00000010, // C-style identifiers, no space operators
       TF_ESCAPESTRINGS = 0x00000020, // Add support for escaping strings
       TF_STRINGSQUOTED = 0x00000040, // Strings must be quoted, otherwise they're keywords
+      TF_BLOCKCOMMENTS = 0x00000080  // supports block comments with /* */
    };
 
 protected:
@@ -94,6 +96,7 @@ protected:
    void doStateInBrackets();
    void doStateQuoted();
    void doStateComment();
+   void doStateBlockComment();
 
    // State table declaration
    static void (XLTokenizer::*States[])();

--- a/source/xl_umapinfo.cpp
+++ b/source/xl_umapinfo.cpp
@@ -474,7 +474,7 @@ void XLUMapInfoParser::startLump()
 void XLUMapInfoParser::initTokenizer(XLTokenizer &tokenizer)
 {
    tokenizer.setTokenFlags(XLTokenizer::TF_OPERATORS | XLTokenizer::TF_ESCAPESTRINGS |
-                           XLTokenizer::TF_STRINGSQUOTED | XLTokenizer::TF_SLASHCOMMENTS);
+                           XLTokenizer::TF_STRINGSQUOTED | XLTokenizer::TF_SLASHCOMMENTS | XLTokenizer::TF_BLOCKCOMMENTS);
 }
 
 //


### PR DESCRIPTION
in order to fix #607 , other ports have block comments in UMAPINFO and this brings EE in line.