### PR TITLE
Add customizable crushed gibs, un-hardcoded crusher gib frame

### DIFF
--- a/source/d_gi.cpp
+++ b/source/d_gi.cpp
@@ -1422,7 +1422,7 @@ static gamemodeinfo_t giDoomRetail =
    "DoomBlood",      // bloodDefaultRIP
    "DoomBlood",      // bloodDefaultCrush
    bloodTypeForActionDOOM, // default behavior for action array
-   "S_GIBS", //default sprite for when things are crushed
+   "S_GIBS", //default frame for when things are crushed
    2,                // skillAmmoMultiplier
    meleecalc_doom,   // monsterMeleeRange
    8 * FRACUNIT,     // itemHeight

--- a/source/d_gi.cpp
+++ b/source/d_gi.cpp
@@ -1160,6 +1160,7 @@ static gamemodeinfo_t giDoomSW =
    "DoomBlood",      // bloodDefaultRIP
    "DoomBlood",      // bloodDefaultCrush
    bloodTypeForActionDOOM, // default behavior for action array
+   "S_GIBS", //default sprite for when things are crushed
    2,                // skillAmmoMultiplier
    meleecalc_doom,   // monsterMeleeRange
    8 * FRACUNIT,     // itemHeight
@@ -1290,6 +1291,7 @@ static gamemodeinfo_t giDoomReg =
    "DoomBlood",      // bloodDefaultRIP
    "DoomBlood",      // bloodDefaultCrush
    bloodTypeForActionDOOM, // default behavior for action array
+   "S_GIBS", //default sprite for when things are crushed
    2,                // skillAmmoMultiplier
    meleecalc_doom,   // monsterMeleeRange
    8 * FRACUNIT,     // itemHeight
@@ -1420,6 +1422,7 @@ static gamemodeinfo_t giDoomRetail =
    "DoomBlood",      // bloodDefaultRIP
    "DoomBlood",      // bloodDefaultCrush
    bloodTypeForActionDOOM, // default behavior for action array
+   "S_GIBS", //default sprite for when things are crushed
    2,                // skillAmmoMultiplier
    meleecalc_doom,   // monsterMeleeRange
    8 * FRACUNIT,     // itemHeight
@@ -1550,6 +1553,7 @@ static gamemodeinfo_t giDoomCommercial =
    "DoomBlood",      // bloodDefaultRIP
    "DoomBlood",      // bloodDefaultCrush
    bloodTypeForActionDOOM, // default behavior for action array
+   "S_GIBS", //default sprite for when things are crushed
    2,                // skillAmmoMultiplier
    meleecalc_doom,   // monsterMeleeRange
    8 * FRACUNIT,     // itemHeight
@@ -1680,6 +1684,7 @@ static gamemodeinfo_t giHereticSW =
    "HereticBlood",         // bloodDefaultRIP
    "HereticBlood",         // bloodDefaultCrush
    bloodTypeForActionHtic, // default blood behavior for action array
+   "", //default sprite for when things are crushed
    1.5,                // skillAmmoMultiplier
    meleecalc_raven,     // monsterMeleeRange
    32 * FRACUNIT,     // itemHeight
@@ -1814,6 +1819,7 @@ static gamemodeinfo_t giHereticReg =
    "HereticBlood",         // bloodDefaultRIP
    "HereticBlood",         // bloodDefaultCrush
    bloodTypeForActionHtic, // default blood behavior for action array
+   "", //default sprite for when things are crushed
    1.5,               // skillAmmoMultiplier
    meleecalc_raven,     // monsterMeleeRange
    32 * FRACUNIT,     // itemHeight

--- a/source/d_gi.h
+++ b/source/d_gi.h
@@ -450,7 +450,7 @@ struct gamemodeinfo_t
    const char *bloodDefaultRIP;    // thingtype of blood shown when thing is impcated by inflictor with "RIP" flag
    const char *bloodDefaultCrush;  // thingtype of blood shown when thing is crushed
    bloodtype_e *defBloodBehaviors; // default blood behavior for action array
-   const char *defCrushSprite;     // default sprite for when things are smashed by crushers
+   const char *defCrushFrame;      // default frame name for when things are smashed by crushers
    double skillAmmoMultiplier;     // how much more ammo to give on baby and nightmare
    meleecalc_e monsterMeleeRange;  // how monster melee range is calculated
    fixed_t itemHeight;             // item pick-up height (independent of thing height)

--- a/source/d_gi.h
+++ b/source/d_gi.h
@@ -450,6 +450,7 @@ struct gamemodeinfo_t
    const char *bloodDefaultRIP;    // thingtype of blood shown when thing is impcated by inflictor with "RIP" flag
    const char *bloodDefaultCrush;  // thingtype of blood shown when thing is crushed
    bloodtype_e *defBloodBehaviors; // default blood behavior for action array
+   const char *defCrushSprite;     // default sprite for when things are smashed by crushers
    double skillAmmoMultiplier;     // how much more ammo to give on baby and nightmare
    meleecalc_e monsterMeleeRange;  // how monster melee range is calculated
    fixed_t itemHeight;             // item pick-up height (independent of thing height)

--- a/source/d_gi.h
+++ b/source/d_gi.h
@@ -450,7 +450,7 @@ struct gamemodeinfo_t
    const char *bloodDefaultRIP;    // thingtype of blood shown when thing is impcated by inflictor with "RIP" flag
    const char *bloodDefaultCrush;  // thingtype of blood shown when thing is crushed
    bloodtype_e *defBloodBehaviors; // default blood behavior for action array
-   const char *defCrushFrame;      // default frame name for when things are smashed by crushers
+   const char *defCrunchFrame;      // default frame name for when things are smashed by crushers
    double skillAmmoMultiplier;     // how much more ammo to give on baby and nightmare
    meleecalc_e monsterMeleeRange;  // how monster melee range is calculated
    fixed_t itemHeight;             // item pick-up height (independent of thing height)

--- a/source/e_things.cpp
+++ b/source/e_things.cpp
@@ -2053,6 +2053,14 @@ bloodtype_e E_GetBloodBehaviorForAction(mobjinfo_t *info, bloodaction_e action)
    return mbb ? mbb->behavior : GameModeInfo->defBloodBehaviors[action];
 }
 
+int E_GetCrushFrame(const Mobj *mo) {
+   const char *spriteKey;
+   const char *defaultFrame = GameModeInfo->defCrushFrame;
+   const char *typeName      = mo->info->meta->getString(spriteKey, defaultFrame);
+   
+   return E_SafeStateName(typeName);
+}
+
 //
 // Creates a thing pickup effect if not already
 //

--- a/source/e_things.h
+++ b/source/e_things.h
@@ -117,6 +117,7 @@ void E_RemoveFromExistingThingPairs(int type, unsigned flag);
 // ioanch 20160220: metastate key names used throughout the code. They also
 // work as DECORATE state label names.
 #define METASTATE_HEAL "Heal"
+#define METASTATE_CRUNCH "Crunch"
 
 // blood types
 enum bloodtype_e : int
@@ -139,7 +140,7 @@ bloodtype_e E_GetBloodBehaviorForAction(mobjinfo_t *info, bloodaction_e action);
 void E_ForEachMobjInfoWithAnyFlags2(unsigned flags,
    bool (*func)(const mobjinfo_t &info, void *context), void *context);
 
-int E_GetCrushFrame(const Mobj *mo);
+int E_GetCrunchFrame(const Mobj *mo);
 
 #endif
 

--- a/source/e_things.h
+++ b/source/e_things.h
@@ -139,6 +139,8 @@ bloodtype_e E_GetBloodBehaviorForAction(mobjinfo_t *info, bloodaction_e action);
 void E_ForEachMobjInfoWithAnyFlags2(unsigned flags,
    bool (*func)(const mobjinfo_t &info, void *context), void *context);
 
+int E_GetCrushFrame(const Mobj *mo);
+
 #endif
 
 // EOF

--- a/source/p_map.cpp
+++ b/source/p_map.cpp
@@ -2807,7 +2807,7 @@ static bool PIT_ChangeSector(Mobj *thing, void *context)
       if(GameModeInfo->type == Game_DOOM)
       {
          thing->skin = nullptr;
-         P_SetMobjState(thing, E_GetCrushFrame(thing));
+         P_SetMobjState(thing, E_GetCrunchFrame(thing));
       }
       thing->flags &= ~MF_SOLID;
       thing->height = thing->radius = 0;

--- a/source/p_map.cpp
+++ b/source/p_map.cpp
@@ -2807,7 +2807,7 @@ static bool PIT_ChangeSector(Mobj *thing, void *context)
       if(GameModeInfo->type == Game_DOOM)
       {
          thing->skin = nullptr;
-         P_SetMobjState(thing, E_SafeState(S_GIBS));
+         P_SetMobjState(thing, E_GetCrushFrame(thing));
       }
       thing->flags &= ~MF_SOLID;
       thing->height = thing->radius = 0;

--- a/source/p_map3d.cpp
+++ b/source/p_map3d.cpp
@@ -925,7 +925,7 @@ static void P_DoCrunch(Mobj *thing)
       if(GameModeInfo->type == Game_DOOM)
       {
          thing->skin = nullptr;
-         P_SetMobjState(thing, E_GetCrushFrame(thing));
+         P_SetMobjState(thing, E_GetCrunchFrame(thing));
       }
       thing->flags &= ~MF_SOLID;
       thing->height = thing->radius = 0;

--- a/source/p_map3d.cpp
+++ b/source/p_map3d.cpp
@@ -918,7 +918,6 @@ static void P_DoCrunch(Mobj *thing)
 {
    // crunch bodies to giblets
    // TODO: support DONTGIB flag like zdoom?
-   // TODO: support custom gib state for actors?
    if(thing->health <= 0)
    {
       // sf: clear the skin which will mess things up
@@ -926,7 +925,7 @@ static void P_DoCrunch(Mobj *thing)
       if(GameModeInfo->type == Game_DOOM)
       {
          thing->skin = nullptr;
-         P_SetMobjState(thing, E_SafeState(S_GIBS));
+         P_SetMobjState(thing, E_GetCrushFrame(thing));
       }
       thing->flags &= ~MF_SOLID;
       thing->height = thing->radius = 0;


### PR DESCRIPTION
In ZDoom-derived ports, you can specify a state a thing will use when its corpse is smushed by a crusher or door. a similar feature is referenced in #496 . With this PR you can specify the frame to be used when a thing is smushed with a new property in gamemodeinfo_t, and in a thing definitions + state blocks, specify a frame or frames to use.

 