### PR TITLE
Reset ANIMDEFS animations on level reload

### DIFF
--- a/source/p_anim.cpp
+++ b/source/p_anim.cpp
@@ -152,6 +152,24 @@ void P_InitHexenAnims()
 }
 
 //
+// P_ResetAnimatedSurfaces
+//
+// Called on level reload to make sure animations begin from their first frame
+//
+void P_ResetAnimatedSurfaces()
+{
+   for(hanimdef_t &had : AnimDefs)
+   {
+      had.currentFrameDef = had.startFrameDef;
+      const hframedef_t &hfd = FrameDefs[had.currentFrameDef];
+      
+      if(had.tics != hfd.tics)
+         had.tics = hfd.tics;
+   }
+}
+
+
+//
 // P_AnimateSurfaces
 //
 // Called every tic in P_Ticker

--- a/source/p_anim.h
+++ b/source/p_anim.h
@@ -22,6 +22,7 @@
 
 void P_InitLightning(void);
 void P_InitHexenAnims();
+void P_ResetAnimatedSurfaces(void);
 void P_AnimateSurfaces(void);
 void P_ForceLightning(void);
 

--- a/source/p_setup.cpp
+++ b/source/p_setup.cpp
@@ -3761,6 +3761,10 @@ void P_SetupLevel(WadDirectory *dir, const char *mapname, int playermask,
       P_PointOnLineSide = P_PointOnLineSideClassic;
       P_PointOnDivlineSide = P_PointOnDivlineSideClassic;
    }
+   
+   // reset hexen animations so they don't desync
+   if(demo_version >= 329)
+      P_ResetAnimatedSurfaces();
 
    // haleyjd 07/22/04: moved up
    newlevel   = (lumpinfo[lumpnum]->source != WadDirectory::IWADSource);


### PR DESCRIPTION
Animations defined with ANIMDEFS up until now have been desynced from the level, simply starting whereever they left off between level loads. This is a compatability issue which is at the root of #576 . With a little function that I added to P_SetupLevel, the problem is solved.