### PR TITLE
Add missileheight and bulletzoffset thing properties -- reborn

### DIFF
--- a/source/a_doom.cpp
+++ b/source/a_doom.cpp
@@ -1510,7 +1510,7 @@ void A_BrainSpit(actionargs_t *actionargs)
    targ = braintargets.wrapIterator();
 
    // spawn brain missile
-   newmobj = P_SpawnMissile(mo, targ, SpawnShotType, mo->z + actor->info->missileheight);
+   newmobj = P_SpawnMissile(mo, targ, SpawnShotType, mo->z + mo->info->missileheight);
    P_SetTarget<Mobj>(&newmobj->target, targ);
    if(!newmobj->state->tics)
    {

--- a/source/a_doom.cpp
+++ b/source/a_doom.cpp
@@ -208,7 +208,7 @@ void A_TroopAttack(actionargs_t *actionargs)
    {
       // launch a missile
       P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_TROOPSHOT),
-                     actor->z + DEFAULTMISSILEZ);
+                     actor->z + actor->info->missileheight);
    }
 }
 
@@ -280,7 +280,7 @@ void A_HeadAttack(actionargs_t *actionargs)
    {
       // launch a missile
       P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_HEADSHOT),
-                     actor->z + DEFAULTMISSILEZ);
+                     actor->z + actor->info->missileheight);
    }
 }
 
@@ -307,7 +307,7 @@ void A_BruisAttack(actionargs_t *actionargs)
    {
       // launch a missile
       P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_BRUISERSHOT),
-                     actor->z + DEFAULTMISSILEZ);  
+                     actor->z + actor->info->missileheight);
    }
 }
 
@@ -363,7 +363,7 @@ void A_BspiAttack(actionargs_t *actionargs)
    
    // launch a missile
    P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_ARACHPLAZ), 
-                  actor->z + DEFAULTMISSILEZ);
+                  actor->z + actor->info->missileheight);
 }
 
 //
@@ -420,7 +420,7 @@ void A_CyberAttack(actionargs_t *actionargs)
    A_FaceTarget(actionargs);
    P_SpawnMissile(actor, actor->target, 
                   E_SafeThingType(MT_ROCKET),
-                  actor->z + DEFAULTMISSILEZ);   
+                  actor->z + actor->info->missileheight);
 }
 
 //=============================================================================
@@ -444,7 +444,7 @@ void A_SkelMissile(actionargs_t *actionargs)
    A_FaceTarget(actionargs);
    actor->z += 16*FRACUNIT;      // so missile spawns higher
    mo = P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_TRACER),
-                       actor->z + DEFAULTMISSILEZ);
+                       actor->z + actor->info->missileheight);
    actor->z -= 16*FRACUNIT;      // back to normal
    
    mo->x += mo->momx;
@@ -913,7 +913,7 @@ void A_FatAttack1(actionargs_t *actionargs)
    Mobj   *actor = actionargs->actor;
    Mobj   *mo;
    int     an;
-   fixed_t z = actor->z + DEFAULTMISSILEZ;
+   fixed_t z = actor->z + actor->info->missileheight;
    int thingType = E_ArgAsThingNumG0(actionargs->args, 0);
    if(thingType < 0)
       thingType = E_SafeThingType(MT_FATSHOT);
@@ -947,7 +947,7 @@ void A_FatAttack2(actionargs_t *actionargs)
    Mobj   *actor = actionargs->actor;
    Mobj   *mo;
    int     an;
-   fixed_t z = actor->z + DEFAULTMISSILEZ;
+   fixed_t z = actor->z + actor->info->missileheight;
    int thingType = E_ArgAsThingNumG0(actionargs->args, 0);
    if(thingType < 0)
       thingType = E_SafeThingType(MT_FATSHOT);
@@ -980,7 +980,7 @@ void A_FatAttack3(actionargs_t *actionargs)
    Mobj   *actor = actionargs->actor;
    Mobj   *mo;
    int     an;
-   fixed_t z = actor->z + DEFAULTMISSILEZ;
+   fixed_t z = actor->z + actor->info->missileheight;
    int thingType = E_ArgAsThingNumG0(actionargs->args, 0);
    if(thingType < 0)
       thingType = E_SafeThingType(MT_FATSHOT);
@@ -1510,7 +1510,7 @@ void A_BrainSpit(actionargs_t *actionargs)
    targ = braintargets.wrapIterator();
 
    // spawn brain missile
-   newmobj = P_SpawnMissile(mo, targ, SpawnShotType, mo->z + DEFAULTMISSILEZ);
+   newmobj = P_SpawnMissile(mo, targ, SpawnShotType, mo->z + actor->info->missileheight);
    P_SetTarget<Mobj>(&newmobj->target, targ);
    if(!newmobj->state->tics)
    {

--- a/source/a_general.cpp
+++ b/source/a_general.cpp
@@ -92,7 +92,7 @@ void P_Mushroom(Mobj *actor, const int ShotType, const int n, const fixed_t misc
        
          mo = P_SpawnMissileWithDest(actor, actor, 
                                      ShotType,          // Launch fireball
-                                     actor->z + DEFAULTMISSILEZ,
+                                     actor->z + actor->info->missileheight,
                                      x, y, z);
          
          mo->momx = FixedMul(mo->momx, misc2);
@@ -1020,7 +1020,7 @@ void A_MissileAttack(actionargs_t *actionargs)
    ang = (angle_t)(((uint64_t)a << 32) / 360);
 
    // adjust z coordinate
-   z = actor->z + DEFAULTMISSILEZ + z;
+   z = actor->z + actor->info->missileheight + z;
 
    if(!hastarget)
    {
@@ -1099,7 +1099,7 @@ void A_MissileSpread(actionargs_t *actionargs)
    angsweep = (angle_t)(((uint64_t)a << 32) / 360);
 
    // adjust z coordinate
-   z = actor->z + DEFAULTMISSILEZ + z;
+   z = actor->z + actor->info->missileheight + z;
 
    ang = actor->angle - angsweep / 2;
    astep = angsweep / (num - 1);

--- a/source/a_heretic.cpp
+++ b/source/a_heretic.cpp
@@ -177,7 +177,7 @@ void A_MummyAttack2(actionargs_t *actionargs)
    
    mo = P_SpawnMissile(actor, actor->target, 
                        E_SafeThingType(MT_MUMMYFX1),
-                       actor->z + DEFAULTMISSILEZ);
+                       actor->z + actor->info->missileheight);
 
    P_SetTarget<Mobj>(&mo->tracer, actor->target);
 }
@@ -298,7 +298,7 @@ void A_WizardAtk3(actionargs_t *actionargs)
    Mobj *mo;
    angle_t angle;
    fixed_t momz;
-   fixed_t z = actor->z + DEFAULTMISSILEZ;
+   fixed_t z = actor->z + actor->info->missileheight;
    int wizfxType = E_SafeThingType(MT_WIZFX1);
    
    actor->flags3 &= ~MF3_GHOST;
@@ -529,7 +529,7 @@ void A_Srcr2Attack(actionargs_t *actionargs)
 {
    Mobj *actor = actionargs->actor;
    int chance;
-   fixed_t z = actor->z + DEFAULTMISSILEZ;
+   fixed_t z = actor->z + actor->info->missileheight;
    int sor2fx1Type = E_SafeThingType(MT_SOR2FX1);
    int sor2fx2Type = E_SafeThingType(MT_SOR2FX2);
    
@@ -1068,7 +1068,7 @@ void A_BeastAttack(actionargs_t *actionargs)
    }
    else
       P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_BEASTBALL),
-                     actor->z + DEFAULTMISSILEZ);
+                     actor->z + actor->info->missileheight);
 }
 
 void A_BeastPuff(actionargs_t *actionargs)
@@ -1110,7 +1110,7 @@ void A_SnakeAttack(actionargs_t *actionargs)
    S_StartSound(actor, actor->info->attacksound);
    A_FaceTarget(actionargs);
    P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_SNAKEPRO_A),
-                  actor->z + DEFAULTMISSILEZ);
+                  actor->z + actor->info->missileheight);
 }
 
 void A_SnakeAttack2(actionargs_t *actionargs)
@@ -1127,7 +1127,7 @@ void A_SnakeAttack2(actionargs_t *actionargs)
    S_StartSound(actor, actor->info->attacksound);
    A_FaceTarget(actionargs);
    P_SpawnMissile(actor, actor->target, E_SafeThingType(MT_SNAKEPRO_B),
-                  actor->z + DEFAULTMISSILEZ);
+                  actor->z + actor->info->missileheight);
 }
 
 //=============================================================================
@@ -1394,7 +1394,7 @@ void A_LichFire(actionargs_t *actionargs)
 
    // spawn the parent fireball
    baseFire = P_SpawnMissile(actor, target, headfxType, 
-                             actor->z + DEFAULTMISSILEZ);
+                             actor->z + actor->info->missileheight);
    
    // set it to S_HEADFX3_4 so that it doesn't grow
    P_SetMobjState(baseFire, frameNum);
@@ -1494,8 +1494,8 @@ void A_LichAttack(actionargs_t *actionargs)
    if(randAttack < (dist ? 150 : 50))
    {
       // ice attack
-      P_SpawnMissile(actor, target, fxType, actor->z + DEFAULTMISSILEZ);
-      S_StartSound(actor, sfx_hedat2);	
+      P_SpawnMissile(actor, target, fxType, actor->z + actor->info->missileheight);
+      S_StartSound(actor, sfx_hedat2);
    }
    else if(randAttack < (dist ? 200 : 150))
       A_LichFire(actionargs);
@@ -1669,7 +1669,7 @@ void A_ImpMissileAtk(actionargs_t *actionargs)
                    5 + (P_Random(pr_impmelee2) & 7), MOD_HIT);
    }
    else
-      P_SpawnMissile(actor, actor->target, fxType, actor->z + DEFAULTMISSILEZ);
+      P_SpawnMissile(actor, actor->target, fxType, actor->z + actor->info->missileheight);
 }
 
 //

--- a/source/a_mbf21.cpp
+++ b/source/a_mbf21.cpp
@@ -1,4 +1,4 @@
-﻿//
+//
 // The Eternity Engine
 // Copyright(C) 2021 James Haley, Max Waine, et al.
 //
@@ -156,7 +156,7 @@ void A_MonsterProjectile(actionargs_t *actionargs)
    spawnofs_z  = E_ArgAsFixed(args, 4, 0);
 
    A_FaceTarget(actionargs);
-   mo = P_SpawnMissile(actor, actor->target, thingtype, actor->z + DEFAULTMISSILEZ);
+   mo = P_SpawnMissile(actor, actor->target, thingtype, actor->z + actor->info->missileheight);
    if(!mo)
       return;
 

--- a/source/e_things.cpp
+++ b/source/e_things.cpp
@@ -628,19 +628,19 @@ static int E_TranMapCB(cfg_t *, cfg_opt_t *, const char *, void *);
    CFG_MVPROP(ITEM_TNG_DROPITEM,     dropitem_opts, CFGF_MULTI|CFGF_NOCASE   ), \
    CFG_MVPROP(ITEM_TNG_COLSPAWN,     colspawn_opts, CFGF_NOCASE              ), \
    CFG_MVPROP(ITEM_TNG_BLOODBEHAV,   bloodbeh_opts, CFGF_MULTI|CFGF_NOCASE   ), \
-   CFG_FLAG(ITEM_TNG_CLRBLOODBEH,    0,             CFGF_NONE), \
-   CFG_STR(ITEM_TNG_BLOODNORM,       "",            CFGF_NONE), \
-   CFG_STR(ITEM_TNG_BLOODIMPACT,     "",            CFGF_NONE), \
-   CFG_STR(ITEM_TNG_BLOODRIP,        "",            CFGF_NONE), \
-   CFG_STR(ITEM_TNG_BLOODCRUSH,      "",            CFGF_NONE), \
-   CFG_SEC(ITEM_TNG_PFX_PICKUPFX,    tngpfx_opts,   CFGF_NOCASE), \
-   CFG_FLAG(ITEM_TNG_PFX_CLRPICKFX,  0,             CFGF_NONE), \
-   CFG_STR(ITEM_TNG_TRAILTYPE,       "",            CFGF_NONE), \
-   CFG_FLOAT(ITEM_TNG_TRAILZOFFSET,  -8.0f,         CFGF_NONE), \
-   CFG_INT(ITEM_TNG_TRAILCHANCE,     256,           CFGF_NONE), \
-   CFG_INT(ITEM_TNG_TRAILSPARSITY,   0,             CFGF_NONE), \
-   CFG_FLOAT(ITEM_TNG_MISSILEHEIGHT, 32.0f,         CFGF_NONE), \
-   CFG_FLOAT(ITEM_TNG_BULLETZOFFSET, 8.0f,          CFGF_NONE), \
+   CFG_FLAG(ITEM_TNG_CLRBLOODBEH,    0,             CFGF_NONE                ), \
+   CFG_STR(ITEM_TNG_BLOODNORM,       "",            CFGF_NONE                ), \
+   CFG_STR(ITEM_TNG_BLOODIMPACT,     "",            CFGF_NONE                ), \
+   CFG_STR(ITEM_TNG_BLOODRIP,        "",            CFGF_NONE                ), \
+   CFG_STR(ITEM_TNG_BLOODCRUSH,      "",            CFGF_NONE                ), \
+   CFG_SEC(ITEM_TNG_PFX_PICKUPFX,    tngpfx_opts,   CFGF_NOCASE              ), \
+   CFG_FLAG(ITEM_TNG_PFX_CLRPICKFX,  0,             CFGF_NONE                ), \
+   CFG_STR(ITEM_TNG_TRAILTYPE, "", CFGF_NONE), \
+   CFG_FLOAT(ITEM_TNG_TRAILZOFFSET, -8.0f, CFGF_NONE), \
+   CFG_INT(ITEM_TNG_TRAILCHANCE, 256, CFGF_NONE), \
+   CFG_INT(ITEM_TNG_TRAILSPARSITY, 0, CFGF_NONE), \
+   CFG_FLOAT(ITEM_TNG_MISSILEHEIGHT, 32.0f, CFGF_NONE), \
+   CFG_FLOAT(ITEM_TNG_BULLETZOFFSET, 8.0f, CFGF_NONE), \
    CFG_END()
 
 cfg_opt_t edf_thing_opts[] =

--- a/source/e_things.cpp
+++ b/source/e_things.cpp
@@ -234,6 +234,10 @@ constexpr const char ITEM_TNG_PFX_FLAGS[]     = "flags";
 #define ITEM_TNG_TRAILCHANCE   "trail.spawnchance"
 #define ITEM_TNG_TRAILSPARSITY "trail.sparsity"
 
+// Projectile/Hitscan properties
+constexpr const char ITEM_TNG_MISSILEHEIGHT[] = "missileheight";
+constexpr const char ITEM_TNG_BULLETZOFFSET[] = "bulletzoffset";
+
 //
 // Thing groups
 //
@@ -624,17 +628,19 @@ static int E_TranMapCB(cfg_t *, cfg_opt_t *, const char *, void *);
    CFG_MVPROP(ITEM_TNG_DROPITEM,     dropitem_opts, CFGF_MULTI|CFGF_NOCASE   ), \
    CFG_MVPROP(ITEM_TNG_COLSPAWN,     colspawn_opts, CFGF_NOCASE              ), \
    CFG_MVPROP(ITEM_TNG_BLOODBEHAV,   bloodbeh_opts, CFGF_MULTI|CFGF_NOCASE   ), \
-   CFG_FLAG(ITEM_TNG_CLRBLOODBEH,    0,             CFGF_NONE                ), \
-   CFG_STR(ITEM_TNG_BLOODNORM,       "",            CFGF_NONE                ), \
-   CFG_STR(ITEM_TNG_BLOODIMPACT,     "",            CFGF_NONE                ), \
-   CFG_STR(ITEM_TNG_BLOODRIP,        "",            CFGF_NONE                ), \
-   CFG_STR(ITEM_TNG_BLOODCRUSH,      "",            CFGF_NONE                ), \
-   CFG_SEC(ITEM_TNG_PFX_PICKUPFX,    tngpfx_opts,   CFGF_NOCASE              ), \
-   CFG_FLAG(ITEM_TNG_PFX_CLRPICKFX,  0,             CFGF_NONE                ), \
-   CFG_STR(ITEM_TNG_TRAILTYPE, "", CFGF_NONE), \
-   CFG_FLOAT(ITEM_TNG_TRAILZOFFSET, -8.0f, CFGF_NONE), \
-   CFG_INT(ITEM_TNG_TRAILCHANCE, 256, CFGF_NONE), \
-   CFG_INT(ITEM_TNG_TRAILSPARSITY, 0, CFGF_NONE), \
+   CFG_FLAG(ITEM_TNG_CLRBLOODBEH,    0,             CFGF_NONE), \
+   CFG_STR(ITEM_TNG_BLOODNORM,       "",            CFGF_NONE), \
+   CFG_STR(ITEM_TNG_BLOODIMPACT,     "",            CFGF_NONE), \
+   CFG_STR(ITEM_TNG_BLOODRIP,        "",            CFGF_NONE), \
+   CFG_STR(ITEM_TNG_BLOODCRUSH,      "",            CFGF_NONE), \
+   CFG_SEC(ITEM_TNG_PFX_PICKUPFX,    tngpfx_opts,   CFGF_NOCASE), \
+   CFG_FLAG(ITEM_TNG_PFX_CLRPICKFX,  0,             CFGF_NONE), \
+   CFG_STR(ITEM_TNG_TRAILTYPE,       "",            CFGF_NONE), \
+   CFG_FLOAT(ITEM_TNG_TRAILZOFFSET,  -8.0f,         CFGF_NONE), \
+   CFG_INT(ITEM_TNG_TRAILCHANCE,     256,           CFGF_NONE), \
+   CFG_INT(ITEM_TNG_TRAILSPARSITY,   0,             CFGF_NONE), \
+   CFG_FLOAT(ITEM_TNG_MISSILEHEIGHT, 32.0f,         CFGF_NONE), \
+   CFG_FLOAT(ITEM_TNG_BULLETZOFFSET, 8.0f,          CFGF_NONE), \
    CFG_END()
 
 cfg_opt_t edf_thing_opts[] =
@@ -3253,6 +3259,18 @@ void E_ProcessThing(int i, cfg_t *const thingsec, cfg_t *pcfg, const bool def)
 
    if(IS_SET(ITEM_TNG_TRAILSPARSITY))
       mobjinfo[i]->trailsparsity = cfg_getint(thingsec, ITEM_TNG_TRAILSPARSITY);
+   
+   if(IS_SET(ITEM_TNG_MISSILEHEIGHT))
+   {
+      tempfloat = cfg_getfloat(thingsec, ITEM_TNG_MISSILEHEIGHT);
+      mobjinfo[i]->missileheight = M_FloatToFixed(tempfloat);
+   }
+   
+   if(IS_SET(ITEM_TNG_BULLETZOFFSET))
+   {
+      tempfloat = cfg_getfloat(thingsec, ITEM_TNG_BULLETZOFFSET);
+      mobjinfo[i]->bulletzoffset = M_FloatToFixed(tempfloat);
+   }
 
    // Process DECORATE state block
    E_ProcessDecorateStatesRecursive(thingsec, i, false);

--- a/source/info.h
+++ b/source/info.h
@@ -439,6 +439,8 @@ struct mobjinfo_t
    int trailzoffset;    // [XA] 02/22/2020: projectile trail z offset (fixed point)
    int trailchance;     // [XA] 02/22/2020: projectile trail spawn chance (out of 255)
    int trailsparsity;   // [XA] 02/22/2020: projectile trail sparsity
+   int missileheight;   // sinku 14/02/2024: height from bottom for missile attacks
+   int bulletzoffset;   // sinku 14/02/2024: offset from centre for bullet attacks
 
    e_pickupfx_t *pickupfx;
 

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -3537,7 +3537,7 @@ Mobj *P_SpawnPlayerMissile(Mobj* source, mobjtype_t type, unsigned flags,
 
    x = source->x;
    y = source->y;
-   z = source->z + source->info->missilezoffset - source->floorclip;
+   z = source->z + source->info->missileheight - source->floorclip;
    if(flags & SPM_ADDSLOPETOZ)
       z += playersightslope;
 

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -3537,7 +3537,7 @@ Mobj *P_SpawnPlayerMissile(Mobj* source, mobjtype_t type, unsigned flags,
 
    x = source->x;
    y = source->y;
-   z = source->z + 4*8*FRACUNIT - source->floorclip;
+   z = source->z + source->info->missilezoffset - source->floorclip;
    if(flags & SPM_ADDSLOPETOZ)
       z += playersightslope;
 

--- a/source/p_mobj.h
+++ b/source/p_mobj.h
@@ -76,7 +76,8 @@ class  BloodSpawner;
 #define MAXGEAR (OVERDRIVE+16)
 
 // haleyjd 11/28/02: default z coord addend for missile spawn
-#define DEFAULTMISSILEZ (4*8*FRACUNIT)
+//#define DEFAULTMISSILEZ (4*8*FRACUNIT)
+// DEFAULTMISSILEZ is now a mobjinfo property (missileheight)
 
 #define NUMMOBJCOUNTERS 8
 

--- a/source/p_trace.cpp
+++ b/source/p_trace.cpp
@@ -752,7 +752,7 @@ void P_LineAttack(Mobj *t1, angle_t angle, fixed_t distance,
    x2 = t1->x + (distance >> FRACBITS) * (trace.cos = finecosine[angle]);
    y2 = t1->y + (distance >> FRACBITS) * (trace.sin = finesine[angle]);
    
-   trace.z = t1->z - t1->floorclip + (t1->height>>1) + 8*FRACUNIT;
+   trace.z = t1->z - t1->floorclip + (t1->height>>1) + (t1->info->bulletzoffset);
    trace.attackrange = distance;
    trace.aimslope = slope;
 


### PR DESCRIPTION
With permission from Xaser I dusted off and made the requested changes to this old PR to add missileheight and bulletzoffset thing properties. To quote the old PR:

- **missileheight**: Height to spawn missile attacks at (relative to actor's z position).
- **bulletzoffset**: Z-offset for bullet attacks (relative to actor's center).

I believe it will be as useful and convenient as Xaser said and un-hardcoding some more values is good.
