### PR TITLE
New parameterized codepointers

### DIFF
--- a/source/a_general.cpp
+++ b/source/a_general.cpp
@@ -1772,19 +1772,29 @@ void A_SelfDestruct(actionargs_t *actionargs)
 //
 // Similar to ZDoom A_BFGSpray extensions.
 //
-// args[0] -- thing to spawn on actors (default MT_EXTRABFG)
+// args[0] -- thing to spawn on actors (no default)
 // args[1] -- number of rays to spawn (default 40)
 // args[2] -- fov to spawn rays (default 90 degrees)
 // args[3] -- number of times to roll for damage (default 15)
+// args[4] -- damage type (default MOD_BFG_SPLASH)
 //
 void A_BFGSprayEx(actionargs_t *actionargs)
 {
    Mobj *mo = actionargs->actor;
+   arglist_t *args = actionargs->args;
+   int thingnum, raynum, damroll, mod;
+   angle_t fov;
    
-   for(int i = 0; i < 40; i++)  // offset angles from its attack angle
+   thingnum = E_ArgAsThingNumG0(args, 0);
+   raynum = E_ArgAsInt(args, 1, 40);
+   fov = E_ArgAsAngle(args, 2, ANG90);
+   damroll = E_ArgAsInt(args, 3, 15);
+   mod = E_ArgAsDamageType(args, 4, MOD_BFG_SPLASH)->num;
+   
+   for(int i = 0; i < raynum; i++)  // offset angles from its attack angle
    {
       int j, damage;
-      angle_t an = mo->angle - ANG90/2 + ANG90/40*i;
+      angle_t an = mo->angle - fov/2 + fov/raynum*i;
       
       // mo->target is the originator (player) of the missile
       
@@ -1799,13 +1809,12 @@ void A_BFGSprayEx(actionargs_t *actionargs)
       
       P_SpawnMobj(clip.linetarget->x, clip.linetarget->y,
                   clip.linetarget->z + (clip.linetarget->height>>2),
-                  E_SafeThingType(MT_EXTRABFG));
+                  thingnum);
       
-      for(damage = j = 0; j < 15; j++)
+      for(damage = j = 0; j < damroll; j++)
          damage += (P_Random(pr_bfg)&7) + 1;
       
-      P_DamageMobj(clip.linetarget, mo->target, mo->target, damage,
-                   MOD_BFG_SPLASH);
+      P_DamageMobj(clip.linetarget, mo->target, mo->target, damage, mod);
    }
 }
 

--- a/source/a_general.cpp
+++ b/source/a_general.cpp
@@ -1767,5 +1767,47 @@ void A_SelfDestruct(actionargs_t *actionargs)
       A_Die(actionargs);
 }
 
+//
+// A_BFGSprayEx
+//
+// Similar to ZDoom A_BFGSpray extensions.
+//
+// args[0] -- thing to spawn on actors (default MT_EXTRABFG)
+// args[1] -- number of rays to spawn (default 40)
+// args[2] -- fov to spawn rays (default 90 degrees)
+// args[3] -- number of times to roll for damage (default 15)
+//
+void A_BFGSprayEx(actionargs_t *actionargs)
+{
+   Mobj *mo = actionargs->actor;
+   
+   for(int i = 0; i < 40; i++)  // offset angles from its attack angle
+   {
+      int j, damage;
+      angle_t an = mo->angle - ANG90/2 + ANG90/40*i;
+      
+      // mo->target is the originator (player) of the missile
+      
+      // killough 8/2/98: make autoaiming prefer enemies
+      if(demo_version < 203 ||
+         (P_AimLineAttack(mo->target, an, 16*64*FRACUNIT, true),
+         !clip.linetarget))
+         P_AimLineAttack(mo->target, an, 16*64*FRACUNIT, false);
+      
+      if(!clip.linetarget)
+         continue;
+      
+      P_SpawnMobj(clip.linetarget->x, clip.linetarget->y,
+                  clip.linetarget->z + (clip.linetarget->height>>2),
+                  E_SafeThingType(MT_EXTRABFG));
+      
+      for(damage = j = 0; j < 15; j++)
+         damage += (P_Random(pr_bfg)&7) + 1;
+      
+      P_DamageMobj(clip.linetarget, mo->target, mo->target, damage,
+                   MOD_BFG_SPLASH);
+   }
+}
+
 // EOF
 

--- a/source/d_dehtbl.cpp
+++ b/source/d_dehtbl.cpp
@@ -1786,6 +1786,7 @@ deh_bexptr deh_bexptrs[] =
    POINTER(SelfDestruct),
    POINTER(TurnProjectile),
    POINTER(SubtractAmmo),
+   POINTER(BFGSprayEx),
 
    // haleyjd 07/13/03: nuke specials
    POINTER(PainNukeSpec),

--- a/source/d_dehtbl.cpp
+++ b/source/d_dehtbl.cpp
@@ -1392,6 +1392,8 @@ void A_SelfDestruct(actionargs_t *);
 void A_TurnProjectile(actionargs_t *);
 void A_SubtractAmmo(actionargs_t *);
 void A_BFGSprayEx(actionargs_t *);
+void A_VileTargetEx(actionargs_t *);
+void A_VileAttackEx(actionargs_t *);
 
 // MaxW: MBF21 pointers
 void A_SpawnObject(actionargs_t *actionargs);
@@ -1787,6 +1789,8 @@ deh_bexptr deh_bexptrs[] =
    POINTER(TurnProjectile),
    POINTER(SubtractAmmo),
    POINTER(BFGSprayEx),
+   POINTER(VileTargetEx),
+   POINTER(VileAttackEx),
 
    // haleyjd 07/13/03: nuke specials
    POINTER(PainNukeSpec),

--- a/source/d_dehtbl.cpp
+++ b/source/d_dehtbl.cpp
@@ -1391,6 +1391,7 @@ void A_SargAttack12(actionargs_t *actionargs);
 void A_SelfDestruct(actionargs_t *);
 void A_TurnProjectile(actionargs_t *);
 void A_SubtractAmmo(actionargs_t *);
+void A_BFGSprayEx(actionargs_t *);
 
 // MaxW: MBF21 pointers
 void A_SpawnObject(actionargs_t *actionargs);

--- a/source/p_pspr.cpp
+++ b/source/p_pspr.cpp
@@ -1556,12 +1556,13 @@ static argkeywd_t cpmkwds =
 // args[4] : sound to make (dehacked number)
 // args[5] : range
 // args[6] : pufftype
+// args[7] : enable face-to-target (when nonzero)
 //
 void A_CustomPlayerMelee(actionargs_t *actionargs)
 {
    angle_t angle;
    fixed_t slope;
-   int damage, dmgfactor, dmgmod, berzerkmul, deftype;
+   int damage, dmgfactor, dmgmod, berzerkmul, deftype, forceview;
    fixed_t range;
    sfxinfo_t *sfx;
    Mobj      *mo = actionargs->actor;
@@ -1582,6 +1583,7 @@ void A_CustomPlayerMelee(actionargs_t *actionargs)
    sfx        = E_ArgAsSound(args, 4);
    range      = E_ArgAsFixed(args, 5, MELEERANGE);
    const char *pufftype = E_ArgAsString(args, 6, nullptr);
+   forceview  = E_ArgAsInt(args, 7, 1);
 
    // adjust parameters
 
@@ -1623,10 +1625,13 @@ void A_CustomPlayerMelee(actionargs_t *actionargs)
    // start sound
    P_WeaponSoundInfo(mo, sfx);
 
-   // turn to face target
-   player->mo->angle = P_PointToAngle(mo->x, mo->y,
-                                      getThingX(mo, clip.linetarget),
-                                      getThingY(mo, clip.linetarget));
+   // turn to face target if nonzero
+   if(forceview)
+   {
+      player->mo->angle = P_PointToAngle(mo->x, mo->y,
+                                         getThingX(mo, clip.linetarget),
+                                         getThingY(mo, clip.linetarget));
+   }
 
    // apply chainsaw deflection if selected
    if(deftype == 3)


### PR DESCRIPTION
Codepointers added:
- **A_BFGSprayEx**: customizable BFGSpray; set ray puff, number of rays, ray fov, cumulative damageroll and damagetype
- **A_VileTargetEx**: customizable VileTarget; spawns the specified thing and sets it up as VileFire would be
- **A_VileAttackEx** customizable VileAttack; custom sound, flat damage, explosion damage/radius and upward velocity

Altered codepointers:
- **A_CustomPlayerMelee**: new parameter for disabling the face-to-target behavior of standard melee attacks