### PR TITLE
Add flag to activate terrain hits when going through portal floors

### DIFF
--- a/source/e_exdata.cpp
+++ b/source/e_exdata.cpp
@@ -330,7 +330,7 @@ static dehflags_t sectorportalflags[] =
    { "ADDITIVE",     PS_ADDITIVE     },
    { "USEGLOBALTEX", PS_USEGLOBALTEX },
    { "ATTACHEDPORTAL", PF_ATTACHEDPORTAL },
-   { "DOTERRAINHIT", PS_DOTERRAINHIT },
+   { "DOTERRAINHIT", PF_DOTERRAINHIT },
    { nullptr,        0               }
 };
 

--- a/source/e_exdata.cpp
+++ b/source/e_exdata.cpp
@@ -330,6 +330,7 @@ static dehflags_t sectorportalflags[] =
    { "ADDITIVE",     PS_ADDITIVE     },
    { "USEGLOBALTEX", PS_USEGLOBALTEX },
    { "ATTACHEDPORTAL", PF_ATTACHEDPORTAL },
+   { "DOTERRAINHIT", PS_DOTERRAINHIT },
    { nullptr,        0               }
 };
 

--- a/source/e_udmf.cpp
+++ b/source/e_udmf.cpp
@@ -260,6 +260,7 @@ void UDMFParser::loadSectors(UDMFSetupSettings &setupSettings) const
             ss->srf.floor.pflags |= PS_OBLENDFLAGS; // PS_OBLENDFLAGS is PS_OVERLAY | PS_ADDITIVE
          ss->srf.floor.pflags |= us.portal_floor_useglobaltex ? PS_USEGLOBALTEX : 0;
          ss->srf.floor.pflags |= us.portal_floor_attached ? PF_ATTACHEDPORTAL : 0;
+         ss->srf.floor.pflags |= us.portal_floor_doterrain ? PS_DOTERRAINHIT : 0;
 
          // Ceilings
          balpha = us.alphaceiling >= 1.0 ? 255 : us.alphaceiling <= 0 ? 
@@ -729,6 +730,7 @@ enum token_e
    t_portal_ceil_useglobaltex,
    t_portalfloor,
    t_portal_floor_attached,
+   t_portal_floor_doterrain,
    t_portal_floor_blocksound,
    t_portal_floor_disabled,
    t_portal_floor_nopass,
@@ -900,6 +902,7 @@ static keytoken_t gTokenList[] =
    TOKEN(portal_ceil_useglobaltex),
    TOKEN(portalfloor),
    TOKEN(portal_floor_attached),
+   TOKEN(portal_floor_doterrain),
    TOKEN(portal_floor_blocksound),
    TOKEN(portal_floor_disabled),
    TOKEN(portal_floor_nopass),
@@ -1315,6 +1318,7 @@ bool UDMFParser::parse(WadDirectory &setupwad, int lump)
                      READ_BOOL(sector, portal_floor_norender);
                      READ_BOOL(sector, portal_floor_useglobaltex);
                      READ_BOOL(sector, portal_floor_attached);
+                     READ_BOOL(sector, portal_floor_doterrain);
 
                      READ_STRING(sector, portal_ceil_overlaytype);
                      READ_NUMBER(sector, alphaceiling);

--- a/source/e_udmf.cpp
+++ b/source/e_udmf.cpp
@@ -260,7 +260,7 @@ void UDMFParser::loadSectors(UDMFSetupSettings &setupSettings) const
             ss->srf.floor.pflags |= PS_OBLENDFLAGS; // PS_OBLENDFLAGS is PS_OVERLAY | PS_ADDITIVE
          ss->srf.floor.pflags |= us.portal_floor_useglobaltex ? PS_USEGLOBALTEX : 0;
          ss->srf.floor.pflags |= us.portal_floor_attached ? PF_ATTACHEDPORTAL : 0;
-         ss->srf.floor.pflags |= us.portal_floor_doterrain ? PS_DOTERRAINHIT : 0;
+         ss->srf.floor.pflags |= us.portal_floor_doterrain ? PF_DOTERRAINHIT : 0;
 
          // Ceilings
          balpha = us.alphaceiling >= 1.0 ? 255 : us.alphaceiling <= 0 ? 

--- a/source/e_udmf.h
+++ b/source/e_udmf.h
@@ -410,6 +410,7 @@ private:
       bool         portal_floor_useglobaltex;
       qstring      portal_floor_overlaytype; // OVERLAY and ADDITIVE consolidated into a single property
       bool         portal_floor_attached;
+      bool         portal_floor_doterrain;
       double       alphafloor;
 
       int          portalceiling;   // floor portal id

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -1786,7 +1786,7 @@ void Mobj::Think()
       waterstate = 0;
    
    sector_t *ps = subsector->sector;
-   if((ps->srf.floor.pflags & PS_DOTERRAINHIT))
+   if((ps->srf.floor.pflags & PF_DOTERRAINHIT))
    {
       waterstate = ((z < P_PortalZ(ps->srf.floor)) && (lz > P_PortalZ(ps->srf.floor)));
    }

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -1786,7 +1786,7 @@ void Mobj::Think()
       waterstate = 0;
    
    sector_t *ps = subsector->sector;
-   if(ps->srf.floor.pflags & PS_OVERLAY)
+   if((ps->srf.floor.pflags & PS_DOTERRAINHIT))
    {
       waterstate = ((z < P_PortalZ(ps->srf.floor)) && (lz > P_PortalZ(ps->srf.floor)));
    }

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -1784,6 +1784,14 @@ void Mobj::Think()
    }
    else
       waterstate = 0;
+   
+   sector_t *ps = subsector->sector;
+   if(ps->srf.floor.pflags & PS_OVERLAY)
+   {
+      waterstate = ((z < P_PortalZ(ps->srf.floor)) && (lz > P_PortalZ(ps->srf.floor)));
+   }
+   else
+      waterstate = 0;
 
    if(flags & (MF_MISSILE|MF_BOUNCES))
    {

--- a/source/r_portal.h
+++ b/source/r_portal.h
@@ -102,11 +102,11 @@ typedef enum
    // More flags added along...
    PF_ATTACHEDPORTAL     = 0x400,
    // Do a terrain hit when you pass this surface
-   PS_DOTERRAINHIT       = 0x410,
+   PF_DOTERRAINHIT       = 0x600,
 
    // Mask for the flags portion
    PF_FLAGMASK           = PF_DISABLED | PF_NORENDER | PF_NOPASS | PF_BLOCKSOUND
-   | PF_ATTACHEDPORTAL,
+   | PF_ATTACHEDPORTAL | PF_DOTERRAINHIT,
 
 
    // -- Opactiy --

--- a/source/r_portal.h
+++ b/source/r_portal.h
@@ -101,6 +101,8 @@ typedef enum
 
    // More flags added along...
    PF_ATTACHEDPORTAL     = 0x400,
+   // Do a terrain hit when you pass this surface
+   PS_DOTERRAINHIT       = 0x410,
 
    // Mask for the flags portion
    PF_FLAGMASK           = PF_DISABLED | PF_NORENDER | PF_NOPASS | PF_BLOCKSOUND


### PR DESCRIPTION
Right now, portal floors with overlays for things like liquids will not do terrain hits. This leads to modders having to do some messed up hack involving boom deep water in order to use a portal for deep water but also get the terrain hits. This solution, letting users of ExtraData or UDMF set a flag that will make the portal use the floor's terrain hit, is backwards-compatible and simple.