### PR TITLE
Fix close button in IWAD picker window

### DIFF
--- a/source/sdl/i_picker.cpp
+++ b/source/sdl/i_picker.cpp
@@ -489,6 +489,9 @@ static void I_Pick_MainLoop(void)
       {
          switch(ev.type)
          {
+         case SDL_QUIT:
+            I_Pick_DoAbort();
+            break;
          case SDL_MOUSEBUTTONDOWN:
             I_Pick_MouseEvent(&ev, &doloop);
             break;


### PR DESCRIPTION
Currently clicking the "X" close button in the IWAD picker window has no effect. The fix handles the event properly.