### PR TITLE
Take scripts and archviles into account for the level statistics

### DIFF
--- a/source/acs_func.cpp
+++ b/source/acs_func.cpp
@@ -2368,6 +2368,11 @@ static Mobj *ACS_spawn(mobjtype_t type, fixed_t x, fixed_t y, fixed_t z,
 
       if(tid) P_AddThingTID(mo, tid);
       mo->angle = angle;
+
+      // Add thing to kill count
+      if (!((mo->flags ^ MF_COUNTKILL) & (MF_FRIEND | MF_COUNTKILL)))
+         totalkills++;
+
       return mo;
    }
    else

--- a/source/d_player.h
+++ b/source/d_player.h
@@ -205,6 +205,7 @@ struct player_t
 
    // For intermission stats.
    int            killcount;
+   int            displaykillcount; // the level stats on the automap/alternate hud
    int            itemcount;
    int            secretcount;
    bool           didsecret;    // True if secret level has been done.

--- a/source/g_game.cpp
+++ b/source/g_game.cpp
@@ -2456,6 +2456,7 @@ void G_PlayerReborn(int player)
    p->weaponctrs = new WeaponCounterTree();
    
    p->killcount   = killcount;
+   p->displaykillcount = killcount;
    p->itemcount   = itemcount;
    p->secretcount = secretcount;
    p->cheats      = cheats;

--- a/source/hu_boom.cpp
+++ b/source/hu_boom.cpp
@@ -117,7 +117,7 @@ void BoomHUD::DrawStatus(int x, int y)
 
    // haleyjd 06/14/06: restored original colors to K/I/S
    tempstr
-      << FC_RED  "K " FC_GREEN << hu_player.killcount << '/' << totalkills << ' '
+      << FC_RED  "K " FC_GREEN << hu_player.displaykillcount << '/' << totalkills << ' '
       << FC_BLUE "I " FC_GREEN << hu_player.itemcount << '/' << totalitems << ' ';
    
    if (!hud_hidesecrets)

--- a/source/hu_modern.cpp
+++ b/source/hu_modern.cpp
@@ -100,7 +100,7 @@ void ModernHUD::DrawStatus(int x, int y)
 
    if(hud_overlaylayout == HUD_BOOM)
    {
-      tempstr << FC_RED   "K" FC_GRAY "  " << hu_player.killcount   << "/" << totalkills <<
+      tempstr << FC_RED   "K" FC_GRAY "  " << hu_player.displaykillcount   << "/" << totalkills <<
                  FC_BLUE " I" FC_GRAY "  " << hu_player.itemcount   << "/" << totalitems;
       if (!hud_hidesecrets)
       {
@@ -110,7 +110,7 @@ void ModernHUD::DrawStatus(int x, int y)
    }
    else if(hud_overlaylayout == HUD_DISTRIB)
    {
-      tempstr << FC_RED "KILLS" FC_GRAY "  " << hu_player.killcount << "/" << totalkills;
+      tempstr << FC_RED "KILLS" FC_GRAY "  " << hu_player.displaykillcount << "/" << totalkills;
       V_FontWriteText(hud_fssmall, tempstr.constPtr(), x, y - 16, m_screen);
       tempstr.clear();
       tempstr << FC_BLUE "ITEMS" FC_GRAY "  " << hu_player.itemcount << "/" << totalitems;
@@ -124,7 +124,7 @@ void ModernHUD::DrawStatus(int x, int y)
    }
    else
    {
-      tempstr << hu_player.killcount << "/" << totalkills << "  " FC_RED "KILLS";
+      tempstr << hu_player.displaykillcount << "/" << totalkills << "  " FC_RED "KILLS";
       FontWriteTextRAlign(hud_fssmall, tempstr.constPtr(), x, y, m_screen);
       tempstr.clear();
       tempstr << hu_player.itemcount << "/" << totalitems << "  " FC_BLUE "ITEMS";

--- a/source/hu_stuff.cpp
+++ b/source/hu_stuff.cpp
@@ -1519,7 +1519,7 @@ void HUDStatWidget::ticker()
 
    if(statType == STATTYPE_KILLS)
    {
-      snprintf(statkillstr, sizeof(statkillstr), "K: %i/%i", plr->killcount, totalkills);
+      snprintf(statkillstr, sizeof(statkillstr), "K: %i/%i", plr->displaykillcount, totalkills);
       message = statkillstr;
    }
    else if(statType == STATTYPE_ITEMS)

--- a/source/p_inter.cpp
+++ b/source/p_inter.cpp
@@ -1009,7 +1009,10 @@ static void P_KillMobj(Mobj *source, Mobj *target, emod_t *mod)
       if(!(target->flags & MF_FRIEND))
       {
          if(target->flags & MF_COUNTKILL)
+         {
             source->player->killcount++;
+            source->player->displaykillcount++;
+         }
       }
       if(target->player)
       {
@@ -1026,7 +1029,10 @@ static void P_KillMobj(Mobj *source, Mobj *target, emod_t *mod)
       // even those caused by other monsters
       // killough 7/20/98: don't count friends
       if(!(target->flags & MF_FRIEND))
+      {
          players->killcount++;
+         players->displaykillcount++;
+      }
    }
 
    if(target->player)
@@ -2207,6 +2213,12 @@ void P_RaiseCorpse(Mobj *corpse, const Mobj *raiser, const int healsound)
 
    // killough 8/29/98: add to appropriate thread
    corpse->updateThinker();
+
+   if (!((corpse->flags ^ MF_COUNTKILL) & (MF_FRIEND | MF_COUNTKILL)))
+   {
+      player_t* plr = &players[displayplayer];
+      plr->displaykillcount--;
+   }
 }
 
 #if 0

--- a/source/p_setup.cpp
+++ b/source/p_setup.cpp
@@ -3438,7 +3438,7 @@ static void P_ClearPlayerVars()
       if(playeringame[i] && players[i].playerstate == PST_DEAD)
          players[i].playerstate = PST_REBORN;
 
-      players[i].killcount = players[i].secretcount = players[i].itemcount = 0;
+      players[i].killcount = players[i].displaykillcount = players[i].secretcount = players[i].itemcount = 0;
 
       memset(players[i].frags, 0, sizeof(players[i].frags));
 


### PR DESCRIPTION
This PR makes it so the total enemies in a level are updated when an ACS script spawns an enemy. It also removes from the player's kill count on the automap/boom HUD when an archvile resurrects an enemy. This mimics the behavior from Woof! and other similar source ports.