### PR TITLE
Fix libpng build for macOS

### DIFF
--- a/libpng/pngpriv.h
+++ b/libpng/pngpriv.h
@@ -514,18 +514,8 @@
     */
 #  include <float.h>
 
-#  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
-   /* We need to check that <math.h> hasn't already been included earlier
-    * as it seems it doesn't agree with <fp.h>, yet we should really use
-    * <fp.h> if possible.
-    */
-#    if !defined(__MATH_H__) && !defined(__MATH_H) && !defined(__cmath__)
-#      include <fp.h>
-#    endif
-#  else
-#    include <math.h>
-#  endif
+#  include <math.h>
+
 #  if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
    /* Amiga SAS/C: We must include builtin FPU functions when compiling using
     * MATH=68881


### PR DESCRIPTION
Currently, the build fails on macOS 15.5 at libpng due to deprecation of `fp.h`. This is a backport of a fix from v1.6.41 pnggroup/libpng@893b811. Alternatively, perhaps it's good idea to bump in-tree libpng to v1.6.41 fully?