### PR TITLE
ACS TakeInventory big improvement

### DIFF
--- a/changelogs/changes-since-4.5.4.txt
+++ b/changelogs/changes-since-4.5.4.txt
@@ -18,11 +18,14 @@ Features
   - damage type for blast (default: actor's MOD)
   Thanks to sink666 for the wish to have parameters in the pull request.
 * Added damage type (MOD) argument to A_BFGSpray (default: BFG_Splash).
+* The ACS function TakeInventory has been heavily improved. Now, it can be used to take all types of items, as well 
+  as health, armor, weapons, backpacks, and all types of power effects from the player. Also, if the function is 
+  passed a amount of item that is greater than the player actually has, the item will be taken away completely 
+  (previously, it was necessary to specify a number of items equal to what was in the player's inventory, which was a bug).
 
 Bug fixes
 ---------
 * Fixed A_BFGSpray not using the parameter, and always being locked at 40 rays.
 * Fixed bad rendering of specially paletted PNG file for the Heretic episode 2 ending screen.
-* Fixed bad implementation of TakeInventory.
 * Fixed A_CustomPlayerMelee wrong implementation of the angle deflection argument. Now it properly avoid rotating player
   if set to "none". Thanks to sink666's pull request for the catch.

--- a/source/e_inventory.cpp
+++ b/source/e_inventory.cpp
@@ -2396,8 +2396,12 @@ static void E_removeInventorySlot(const player_t *player, inventoryslot_t *slot)
 //
 // Remove some amount of a specific item from the player's inventory, if
 // possible. If amount is less than zero, then all of the item will be removed.
+// 
+// If removemore is true, then if the amount is greater than what is actually 
+// in the inventory, everything will be removed. For compatibility reasons, 
+// this parameter is false by default.
 //
-itemremoved_e E_RemoveInventoryItem(const player_t &player, const itemeffect_t *artifact, int amount)
+itemremoved_e E_RemoveInventoryItem(const player_t &player, const itemeffect_t *artifact, int amount, bool removemore)
 {
     inventoryslot_t *slot = E_InventorySlotForItem(player, artifact);
 
@@ -2409,9 +2413,14 @@ itemremoved_e E_RemoveInventoryItem(const player_t &player, const itemeffect_t *
     if(amount < 0)
         amount = slot->amount;
 
-    // don't own that many?
     if(slot->amount < amount)
-        return INV_NOTREMOVED;
+    {
+        if(removemore)
+            amount = slot->amount;
+        else
+            // don't own that many?
+            return INV_NOTREMOVED;
+    }
 
     itemremoved_e ret = INV_REMOVED;
 

--- a/source/e_inventory.h
+++ b/source/e_inventory.h
@@ -302,7 +302,7 @@ enum autousehealthrestrict_flags : unsigned
 };
 
 // Remove an item from a player's inventory.
-itemremoved_e E_RemoveInventoryItem(const player_t &player, const itemeffect_t *artifact, int amount);
+itemremoved_e E_RemoveInventoryItem(const player_t &player, const itemeffect_t *artifact, int amount, bool removemore = false);
 
 // Call at the end of a hub, or a level that isn't part of a hub, to clear
 // out items that don't persist.

--- a/source/e_weapons.cpp
+++ b/source/e_weapons.cpp
@@ -348,6 +348,30 @@ int E_NumWeaponsInSlotPlayerOwns(const player_t &player, const int slot)
 }
 
 //
+// Check if player has any weapons left
+//
+bool E_PlayerHasAnyWeapons(const player_t &player)
+{
+    for(weaponslot_t *&slot : player.pclass->weaponslots)
+    {
+        if(!slot)
+            continue;
+
+        BDListItem<weaponslot_t> *weaponslot = E_FirstInSlot(slot);
+        do
+        {
+            if(E_PlayerOwnsWeapon(player, weaponslot->bdObject->weapon))
+                return true;
+
+            weaponslot = weaponslot->bdNext;
+        }
+        while(!weaponslot->isDummy());
+    }
+
+    return false;
+}
+
+//
 // If it doesn't have an alt atkstate, it can't have an alt fire
 //
 bool E_WeaponHasAltFire(const weaponinfo_t *wp)
@@ -430,7 +454,8 @@ BDListItem<weaponslot_t> *E_LastInSlot(const weaponslot_t *dummyslot)
 //
 static weaponslot_t *E_findEntryForWeaponInSlot(const weaponinfo_t *wp, const weaponslot_t *slot)
 {
-    if(slot == nullptr)
+    // BUGFIX - Prevent attempt to switch to null wp, otherwise the game will crash
+    if(slot == nullptr || wp == nullptr)
         return nullptr;
 
     auto baseslot = E_FirstInSlot(slot);

--- a/source/e_weapons.h
+++ b/source/e_weapons.h
@@ -201,6 +201,7 @@ bool E_PlayerOwnsWeapon(const player_t &player, const weaponinfo_t *weapon);
 bool E_PlayerOwnsWeaponForDEHNum(const player_t &player, const int dehnum);
 bool E_PlayerOwnsWeaponInSlot(const player_t &player, const int slot);
 int  E_NumWeaponsInSlotPlayerOwns(const player_t &player, const int slot);
+bool E_PlayerHasAnyWeapons(const player_t &player);
 
 state_t *E_GetStateForWeaponInfo(const weaponinfo_t *wi, const char *label);
 

--- a/source/p_inter.h
+++ b/source/p_inter.h
@@ -43,14 +43,19 @@ enum
 };
 
 bool P_GiveAmmoPickup(player_t &, const itemeffect_t *, bool, int, int itemamount = 1);
+bool P_TakeAmmoPickup(player_t &, const itemeffect_t *, int itemamount = 1);
 bool P_GiveBody(player_t &, const itemeffect_t *, int itemamount = 1);
+bool P_TakeBody(player_t &, const itemeffect_t *, int itemamount = 1);
 bool P_GiveArmor(player_t &, const itemeffect_t *, int itemamount = 1);
+bool P_TakeArmor(player_t &, const itemeffect_t *, int itemamount = 1);
 // MaxW 2016/07/23: P_GivePower is no longer required for external use;
 // previously it was used in m_cheats, but the CheatX powereffects mean
 // that P_GivePowerForItem can be used.
 bool P_GivePowerForItem(player_t &, const itemeffect_t *, int itemamount = 1);
+bool P_TakePowerForItem(player_t &, const itemeffect_t *, int itemamount = 1);
 
 bool P_GivePower(player_t &player, int power, int duration, bool permanent, bool additiveTime, int itemamount = 1);
+bool P_TakePower(player_t &player, int power, int itemamount = 1);
 void P_TouchSpecialThing(Mobj *special, Mobj *toucher);
 void P_DamageMobj(Mobj *target, Mobj *inflictor, Mobj *source, int damage, int mod);
 void P_DropItems(Mobj *actor, bool tossitems);


### PR DESCRIPTION
TakeInventory has been heavily improved. Now it allows to take almost any items from the player's inventory and more.
Here are some possible ways to use it.

- Health items. You can take a player's health by taking health items from the player. For example, TakeInventory(“HealthBonus”, 5) will take 5 HP from the player, and TakeInventory(“Medikit”, 2) will take 50 HP (25 * 2) from the player. The player will always have at least 1 HP remaining.

- Armor items. Similar to health, it is possible to reduce the player's armor value by taking away armor items. i.e. TakeInventory(“ArmorBonus”, 10) will take away 10 armor from the player, and TakeInventory(“GreenArmor”, 2) will take away 200 armor from the player. When taking armor, armorfactor and armordivisor are not counted, only saveamount. But if there is no armor left at all, then armorfactor and armordivisor will also be reset.

- Ammo items. Can be taken either directly by the piece (TakeInventory(“AmmoClip”, 27) will take exactly 27 rounds) or by ammoeffect (as was the case with armor and medkits), with the skill level taken into account. I.e., TakeInventory(“CellPack”, 2) will take 200 ammo rounds on normal difficulty levels, and 400 on the easiest and nightmare levels.

- PowerUP items. In this case, the duration of a specific powerup will be subtracted from the player's timer. Also, if it is an infinite PowerUP (for example, Berserk or ComputerMap), it will also be taken from the player. If the tome of power is subtracted, the player's currently enhanced weapon will return to normal. TakeInventory(“BlurSphere”, 1) will subtract 60 seconds from the player's current invisibility duration (if create such a sphere with an additive timer in edf, it is possible to subtract it in portions).

- PowerUPs directly. It is possible to specify the power type directly as an item and subtract the number of ticks from the current timer. For example, TakeInventory(“PowerInvulnerable”, 5*35) will subtract exactly 5 seconds of invulnerability from the player. As in the previous case, this works with infinite powerups and tome of power. So TakeInventory(“PowerStrength”, 1) will take away the player's berserk. Also, in the case of powerups, it is possible to specify a negative number, in which case the powerup will be taken away fully, regardless of the amount of time remaining for the player. TakeInventory(“PowerInvulnerable”, -1) will take away the player's invulnerability completely.

- BackpackItem. TakeInventory(“BackpackItem”, 1) will now take the player's backpack and discard the number of ammo carried.

- Also, it is possible to freely take away weapons and other inventory items, including keys. However, if there are no weapons left in the player's inventory, an “empty” weapon will be automatically selected (as in the [case of ClearInventory()](https://github.com/team-eternity/eternity/pull/715)).



[Similarly](https://github.com/team-eternity/eternity/pull/715), a game crash has been fixed here when the game tried to select a non-existent weapon from the inventory.

Also, as a counterpart to TakeInventory(), GiveInventory() has been improved - now, in addition to items, it is possible to directly give powerups with a duration in ticks. For example, GiveInventory(“PowerStrength”, 1) will give berserk, and GiveInventory(“PowerInvulnerable”, 15*35) will give the player 15 seconds of invulnerability.

The behavior is deliberately different from ZDoom, as this implementation provides many more possibilities. On the one hand, it may seem a little strange that you can take health, armor, and other items away, but on the other hand, it opens up many more possibilities for modders, so why not?

I tried to test as many cases as possible in both Doom and Heretic. Perhaps if there are more questionable scenarios for using inventory and especially PowerUP (I spent more time with them), they should be checked before merging into master. I am ready to fix various rough edges if necessary.