### PR TITLE
New EDF codepointer: A_LightEx

### DIFF
--- a/changelogs/changes-since-4.5.4.txt
+++ b/changelogs/changes-since-4.5.4.txt
@@ -1,4 +1,4 @@
-Changes since v4.05.04
+﻿Changes since v4.05.04
 ======================
 
 Features
@@ -29,6 +29,9 @@ Features
   the contribution!
 * Added the comp_thingsectorlight setting, which controls how things are lit in sectors with different floor and ceiling
   lights. Thanks to elf-alchemist for the contribution! Details here: https://github.com/team-eternity/eternity/pull/740
+* New codepointer A_LightEx added, which is an parametrized version of A_Light0/A_Light1/A_Light2. It can be used to 
+  create more complex light sequences, such as a flashlight bright lighting effect. It also can make all darker with 
+  negative brightness values.
 
 Improvements
 ------------

--- a/source/d_dehtbl.cpp
+++ b/source/d_dehtbl.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // The Eternity Engine
 // Copyright (C) 2025 James Haley et al.
 //
@@ -1251,6 +1251,7 @@ void A_SargAttack12(actionargs_t *actionargs);
 void A_SelfDestruct(actionargs_t *);
 void A_TurnProjectile(actionargs_t *);
 void A_SubtractAmmo(actionargs_t *);
+void A_LightEx(actionargs_t *);
 
 // MaxW: MBF21 pointers
 void A_SpawnObject(actionargs_t *actionargs);
@@ -1649,6 +1650,7 @@ deh_bexptr deh_bexptrs[] = {
     POINTER(SelfDestruct),
     POINTER(TurnProjectile),
     POINTER(SubtractAmmo),
+    POINTER(LightEx),
 
     // haleyjd 07/13/03: nuke specials
     POINTER(PainNukeSpec),

--- a/source/p_pspr.cpp
+++ b/source/p_pspr.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // The Eternity Engine
 // Copyright (C) 2025 James Haley et al.
 //
@@ -1260,6 +1260,18 @@ void A_Light2(actionargs_t *actionargs)
 
     if(LevelInfo.useFullBright) // haleyjd
         mo->player->extralight = 2;
+}
+
+void A_LightEx(actionargs_t *actionargs)
+{
+    Mobj     *mo         = actionargs->actor;
+    int const lightdelta = E_ArgAsInt(actionargs->args, 0, 0);
+
+    if(!mo->player)
+        return;
+
+    if(LevelInfo.useFullBright) // haleyjd
+        mo->player->extralight = lightdelta;
 }
 
 //

--- a/source/p_pspr.cpp
+++ b/source/p_pspr.cpp
@@ -1264,14 +1264,34 @@ void A_Light2(actionargs_t *actionargs)
 
 void A_LightEx(actionargs_t *actionargs)
 {
+    if(!LevelInfo.useFullBright)
+        return;
+
     Mobj     *mo         = actionargs->actor;
     int const lightdelta = E_ArgAsInt(actionargs->args, 0, 0);
 
-    if(!mo->player)
-        return;
+    // lighter than the current extralight? if so, apply it. otherwise, leave it alone.
+    // lighter has higher priority, than darker, so that multiple lightdelta changes can
+    // be applied in the same tic without worrying about order of execution and screen
+    // flickering.
+    auto applyLight = [lightdelta](player_t &player) {
+        if(!player.extralight || player.extralight <= lightdelta)
+            player.extralight = lightdelta;
+    };
 
-    if(LevelInfo.useFullBright) // haleyjd
-        mo->player->extralight = lightdelta;
+    // if caller was a player, apply the lightdelta to that player only
+    if(mo->player)
+    {
+        applyLight(*mo->player);
+        return;
+    }
+
+    // otherwise, apply the lightdelta to all players in the game
+    for(int pnum = 0; pnum < MAXPLAYERS; ++pnum)
+    {
+        if(playeringame[pnum])
+            applyLight(players[pnum]);
+    }
 }
 
 //

--- a/source/r_plane.cpp
+++ b/source/r_plane.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // The Eternity Engine
 // Copyright (C) 2025 James Haley et al.
 //
@@ -200,8 +200,12 @@ static int R_spanLight(const cb_plane_t &plane, float dist)
 static void R_planeLight(cb_plane_t &plane)
 {
     // This formula was taken (almost) directly from r_main.c where the zlight
-    // table is generated.
-    plane.startmap = 2.0f * (30.0f - (plane.lightlevel / 8.0f));
+    // table is generated. The only difference is that the extralight component 
+    // is added here, because extralight must affect planes as well as walls 
+    // and sprites, and the zlight table is only used for walls and sprites. 
+    // The formula is designed to give the same result as the zlight table, but 
+    // with the extralight component added in.
+    plane.startmap = 2.0f * (30.0f - (plane.lightlevel / 8.0f)) + 1 - (extralight * LIGHTBRIGHT);
 }
 
 //

--- a/source/r_plane.cpp
+++ b/source/r_plane.cpp
@@ -300,9 +300,10 @@ static void R_slopeLights(const cb_plane_t &plane, int x1, int x2, double startc
 
     for(i = 0; i < len; i++)
     {
-        int index = (int)(map >> FRACBITS) + 1;
-
-        index -= (extralight * LIGHTBRIGHT);
+        // The factor of 2 was introduced here based on empirical testing — with this formula, 
+        // lighting on slopes is calculated visually correctly regardless of how much the area 
+        // with the slopes is brightened or darkened.
+        int index = (int)(map >> FRACBITS) + (1 - (extralight * LIGHTBRIGHT)) * 2;
 
         if(index < 0)
             cb_slopespan_t::colormap[i + x1] = (byte *)(plane.colormap);


### PR DESCRIPTION
# Feature
The new codepointer A_LightEx(int lightDelta). Essentially, it is a parameterized version of A_Light0, A_Light1, and A_Light2.
- lightDelta - a number indicating how much the render brightness around the player should change. Positive values will make everything brighter, while negative values will make everything darker.

It’s useful for various ideas, but I personally created it to enable the creation of a fully functional flashlight.

If the calling object is a player, the effect will apply only to that player. If the function is called by an entity that is not a player, the effect will apply to all players in the game. This allows you to create, for example, a monster that begins to obscure players' vision when it spots them.

There is also a priority system in place if multiple A_LightEx instances are called in a single tick. The brighter one always takes priority. This prevents the player from experiencing unpleasant flickering on the screen when dimming and brightening effects are triggered simultaneously.

There is also a minor adjustment to how lighting is calculated on flat surfaces (floors and ceilings). For some reason, the `extralight` parameter, which is used during A_Light sequences, was not being applied when calculating the brightness levels of floors and ceilings. This has been fixed. For standard A_Light0, A_Light1, and A_Light2, this fix is imperceptible, but at sufficiently high values, it is necessary to eliminate a rather ugly visual result. The slope rendering has also been fixed.

# Showcase
Flashlight with A_LightEx(4):

https://github.com/user-attachments/assets/c4154837-7929-4e6b-8a25-537a809a5236

Flashlight with A_LightEx(-8):

https://github.com/user-attachments/assets/6c8d6562-3af0-462d-9753-7e5f15853926

Flashlight with A_LightEx(10):

https://github.com/user-attachments/assets/eea3130b-c1c2-4a21-a283-a95daf6e5753

Flashlight with A_LightEx(10), but without fixing the lighting rendering on the planes (for comparison, so it's clear just how ugly it looks):

https://github.com/user-attachments/assets/4bfe8921-63ce-4a58-919d-1b821ad82fad

Flashlight with A_LightEx(6) on slopes:

https://github.com/user-attachments/assets/70ae5477-9310-42a7-b1aa-2069e3a1936c