### PR TITLE
New NOSEEKINVISIBLE and IGNORESEEKER thing type flags

### DIFF
--- a/changelogs/changes-since-4.5.4.txt
+++ b/changelogs/changes-since-4.5.4.txt
@@ -1,4 +1,4 @@
-Changes since v4.05.04
+﻿Changes since v4.05.04
 ======================
 
 Features
@@ -19,6 +19,9 @@ Features
   - damage type for blast (default: actor's MOD)
   Thanks to sink666 for the wish to have parameters in the pull request.
 * Added damage type (MOD) argument to A_BFGSpray (default: BFG_Splash).
+* New thing type flag NOSEEKINVISIBLE for projectiles, which prevents the seeker from targeting players with 
+  invisibility powerup active.
+* New thing type flag IGNORESEEKER for things, which prevents them from being targeted by seekers.
 
 Improvements
 ------------

--- a/source/a_decorate.cpp
+++ b/source/a_decorate.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // The Eternity Engine
 // Copyright (C) 2025 James Haley et al.
 //
@@ -546,6 +546,12 @@ void A_SeekerMissile(actionargs_t *actionargs)
     // adjust direction
     dest = actor->tracer;
 
+    if(dest && !P_SeekerCanTrack(actor, dest))
+    {
+        P_ClearTarget(actor->tracer);
+        dest = nullptr;
+    }
+
     if(!dest || dest->health <= 0)
     {
         if((flags & SMF_LOOK) && P_Random(pr_seekermissile) < chance)
@@ -567,6 +573,9 @@ void A_SeekerMissile(actionargs_t *actionargs)
                 // don't aim for shooter, or for friends of shooter
                 if(clip.linetarget)
                 {
+                    if(!P_SeekerCanTrack(actor, clip.linetarget))
+                        continue;
+
                     if(clip.linetarget == actor->target || //
                        (clip.linetarget->flags & actor->target->flags & MF_FRIEND))
                         continue;

--- a/source/a_doom.cpp
+++ b/source/a_doom.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // The Eternity Engine
 // Copyright (C) 2025 James Haley et al.
 //
@@ -495,6 +495,12 @@ void A_Tracer(actionargs_t *actionargs)
 
     if(!dest || dest->health <= 0)
         return;
+
+    if(!P_SeekerCanTrack(actor, dest))
+    {
+        P_ClearTarget(actor->tracer);
+        return;
+    }
 
     fixed_t dx = getThingX(actor, dest);
     fixed_t dy = getThingY(actor, dest);

--- a/source/a_general.cpp
+++ b/source/a_general.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // The Eternity Engine
 // Copyright (C) 2025 James Haley et al.
 //
@@ -832,6 +832,12 @@ void A_GenTracer(actionargs_t *actionargs)
 
     if(!dest || dest->health <= 0)
         return;
+
+    if(!P_SeekerCanTrack(actor, dest))
+    {
+        P_ClearTarget(actor->tracer);
+        return;
+    }
 
     // ioanch 20151230: portal-aware
     fixed_t dx = getThingX(actor, dest);

--- a/source/a_mbf21.cpp
+++ b/source/a_mbf21.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // The Eternity Engine
 // Copyright (C) 2025 James Haley, Max Waine, et al.
 //
@@ -390,6 +390,9 @@ void A_FindTracer(actionargs_t *actionargs)
         // don't aim for shooter, or for friends of shooter
         if(clip.linetarget)
         {
+            if(!P_SeekerCanTrack(actor, clip.linetarget))
+                continue;
+
             if(clip.linetarget == actor->target || (clip.linetarget->flags & actor->target->flags & MF_FRIEND))
                 continue;
 

--- a/source/d_deh.cpp
+++ b/source/d_deh.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // The Eternity Engine
 // Copyright (C) 2025 James Haley et al.
 //
@@ -408,6 +408,8 @@ static dehflags_t deh_mobjflags[] = {
     { "NOTAUTOAIMED",       0x00000001, 4 }, // can't be autoaimed (for real)
     { "FULLVOLSOUNDS",      0x00000002, 4 }, // full-volume see/death sounds
     { "ACTLIKEBRIDGE",      0x00000004, 4 }, // unmoved by sector actions, and pickups can sit atop
+    { "NOSEEKINVISIBLE",    0x00000008, 4 }, // seeker missiles ignore invisible targets
+    { "IGNORESEEKER", 	    0x00000010, 4 }, // invisible to seeker missiles
 
     { nullptr,             0 }             // nullptr terminator
 };

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // The Eternity Engine
 // Copyright (C) 2025 James Haley et al.
 //
@@ -3875,6 +3875,12 @@ bool P_SeekerMissile(Mobj *actor, const angle_t threshold, const angle_t maxturn
         return false;
     }
 
+    if(!P_SeekerCanTrack(actor, dest))
+    {
+        P_ClearTarget(actor->tracer);
+        return false;
+    }
+
     // ioanch 20151230: portal aware
     fixed_t dx = getThingX(actor, dest);
     fixed_t dy = getThingY(actor, dest);
@@ -4415,6 +4421,24 @@ void P_NeutralizeForRemoval(Mobj &mobj)
     mobj.flags3                       &= ~(MF3_PASSMOBJ);
     mobj.player                        = nullptr;
     mobj.health                        = -1000;
+}
+
+//
+// P_SeekerCanTrack
+//
+// Checks if a seeker can track a target, based on the seeker's
+// flags and the target's invisibility status.
+//
+bool P_SeekerCanTrack(const Mobj *actor, const Mobj *target)
+{
+    if(!actor || !target || target->flags5 & MF5_IGNORESEEKER)
+        return false;
+
+    if(actor->flags5 & MF5_NOSEEKINVISIBLE)
+        return !(target->player && (target->player->powers[pw_invisibility].isActive() ||
+                                    target->player->powers[pw_totalinvis].isActive()));
+
+    return true;
 }
 
 #if 0

--- a/source/p_mobj.h
+++ b/source/p_mobj.h
@@ -1,4 +1,4 @@
-//
+﻿//
 // The Eternity Engine
 // Copyright (C) 2025 James Haley et al.
 //
@@ -775,13 +775,15 @@ enum mobjflags4_e : unsigned int
 
 enum mobjflags5_e : unsigned int
 {
-    MF5_NOTAUTOAIMED  = 0x00000001, // can't be autoaimed (for real)
-    MF5_FULLVOLSOUNDS = 0x00000002, // full-volume see/death sounds
-    MF5_ACTLIKEBRIDGE = 0x00000004, // unmoved by sector actions, and pickups can sit atop
+    MF5_NOTAUTOAIMED    = 0x00000001, // can't be autoaimed (for real)
+    MF5_FULLVOLSOUNDS   = 0x00000002, // full-volume see/death sounds
+    MF5_ACTLIKEBRIDGE   = 0x00000004, // unmoved by sector actions, and pickups can sit atop
+    MF5_NOSEEKINVISIBLE = 0x00000008, // seeker missiles ignore invisible targets
+    MF5_IGNORESEEKER    = 0x00000010, // thing is ignored by seeker missiles
 };
 
-// killough 9/15/98: Same, but internal flags, not intended for .deh
-// (some degree of opaqueness is good, to avoid compatibility woes)
+// Returns true if the given seeker missile can track the given target.
+bool P_SeekerCanTrack(const Mobj *actor, const Mobj *target);
 
 //
 // IMPORTANT: if you want to reuse any of the UNUSED bits, remember to increment WRITE_SAVE_VERSION


### PR DESCRIPTION
New thing type flag NOSEEKINVISIBLE for projectiles, which prevents the seeker from targeting players with invisibility powerup active.
New thing type flag IGNORESEEKER for things, which prevents them from being targeted by seekers.

These flags can function independently of one another. NOSEEKINVISIBLE is intended for players and is applied to projectiles. IGNORESEEKER is intended for shootable objects that should not be targeted by homing projectiles (for example, during infighting or from a player’s homing shots).