### PR TITLE
Fixed a IDDIT and IDDKT cheat codes bug

### DIFF
--- a/source/am_map.cpp
+++ b/source/am_map.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // The Eternity Engine
 // Copyright (C) 2026 James Haley et al.
 //
@@ -1155,10 +1155,10 @@ void MobjLookupCheat::showNext(type_e type)
     else
         start_th = th = &thinkercap;
 
-    th = th->next;
-
-    while(th != start_th)
+    do
     {
+        th = th->next;
+
         Mobj *mo = thinker_cast<Mobj *>(th);
 
         if(mo && (!mustBeAlive || mo->health > 0) && mo->flags & flags)
@@ -1167,9 +1167,8 @@ void MobjLookupCheat::showNext(type_e type)
             P_SetTarget(&current, mo);
             break;
         }
-
-        th = th->next;
     }
+    while(th != start_th);
 }
 
 void SecretSectorLookupCheat::showNext()

--- a/source/am_map.cpp
+++ b/source/am_map.cpp
@@ -1124,6 +1124,14 @@ static void AM_moveCenterToPoint(v2fixed_t point)
     AM_changeWindowLoc();
 }
 
+static inline bool IsThinkerInList(const Thinker *candidate)
+{
+    for(Thinker *itr = thinkercap.next; itr != &thinkercap; itr = itr->next)
+        if(itr == candidate)
+            return true;
+    return false;
+}
+
 //
 // Used by player cheat codes to find tally-relevant objects on the map.
 //
@@ -1150,6 +1158,11 @@ void MobjLookupCheat::showNext(type_e type)
     const Thinker *start_th;
     Thinker       *th;
 
+    // Validate current thinker, if any, to allow for the possibility that it was removed from the map since the last
+    // call
+    if(current && !IsThinkerInList(static_cast<Thinker *>(current)))
+        current = nullptr;
+
     if(current)
         start_th = th = static_cast<Thinker *>(current);
     else
@@ -1158,6 +1171,9 @@ void MobjLookupCheat::showNext(type_e type)
     do
     {
         th = th->next;
+
+        if(!th)
+            break;
 
         Mobj *mo = thinker_cast<Mobj *>(th);
 


### PR DESCRIPTION
Fixed a bug where only one item or monster remained on the map, and the iddkt and iddit cheats could no longer display them on the automap more than once (they did nothing when re-entered).

Related to https://github.com/team-eternity/eternity/pull/717