### PR TITLE
add comp_voodooscroller for mbf21

### DIFF
--- a/source/c_net.h
+++ b/source/c_net.h
@@ -102,6 +102,7 @@ enum
     netcmd_comp_jump,       // ioanch:  air control for jumping
     netcmd_comp_aircontrol = netcmd_comp_jump,
     netcmd_comp_thingsectorlight,
+    netcmd_comp_voodooscroller,
     NUMNETCMDS
 };
 

--- a/source/doomstat.h
+++ b/source/doomstat.h
@@ -163,6 +163,7 @@ enum
     comp_jump,       // Disable jumping and air control
     comp_aircontrol = comp_jump,
     comp_thingsectorlight,
+    comp_voodooscroller, // mbf21
     COMP_TOTAL,  // counts the used comps. MUST BE LAST ONE + 1.
     MBF_COMP_TOTAL = 32 // limit on the MBF demo format
 };

--- a/source/g_cmd.cpp
+++ b/source/g_cmd.cpp
@@ -801,6 +801,7 @@ const char *comp_strings[] = {
     "ninja",      //          04/18/10: ninja spawn
     "aircontrol", //
     "thingsectorlight", //
+    "voodooscroller", // mbf21
 };
 
 static void Handler_CompTHeights()

--- a/source/g_game.cpp
+++ b/source/g_game.cpp
@@ -1009,6 +1009,8 @@ struct complevel_s
     { 335, 335, false }, // comp_special
     { 337, 337, false }, // comp_ninja
     { 340, 340, false }, // comp_jump
+    { 406, 406, false }, // comp_thingsectorlight (FIXME: use MBF version number?)
+    { 221, 221, true  }, // comp_voodooscroller
     { 0,   0,   false }
 };
 
@@ -3337,7 +3339,7 @@ byte *G_WriteOptions(byte *demoptr)
     *demoptr++ = monkeys; // byte 26
 
     // killough 10/98: a compatibility vector now
-    for(int i = 0; i < COMP_TOTAL; i++)
+    for(int i = 0; i < emin(COMP_TOTAL, MBF_COMP_TOTAL); i++)
         *demoptr++ = comp[i] != 0; // bytes 27 - 58 : comp
     for(int i = COMP_TOTAL; i < MBF_COMP_TOTAL; i++)
         *demoptr++ = 0; // comp padding
@@ -3427,7 +3429,7 @@ byte *G_ReadOptions(byte *demoptr)
 
         { // killough 10/98: a compatibility vector now
             int i;
-            for(i = 0; i < COMP_TOTAL; ++i)
+            for(i = 0; i < emin(COMP_TOTAL, MBF_COMP_TOTAL); ++i)
                 comp[i] = *demoptr++;
             for(int i = COMP_TOTAL; i < MBF_COMP_TOTAL; i++)
                 demoptr++; // comp padding

--- a/source/m_misc.cpp
+++ b/source/m_misc.cpp
@@ -471,6 +471,9 @@ default_t defaults[] = {
     DEFAULT_INT("comp_thingsectorlight", &default_comp[comp_thingsectorlight], &comp[comp_thingsectorlight], 0, 0, 1,
                 default_t::wad_game, "MObjs are lit by transfered light"),
 
+    DEFAULT_INT("comp_voodooscroller", &default_comp[comp_voodooscroller], &comp[comp_voodooscroller], 0, 0, 1,
+                default_t::wad_game, "Voodoo dolls on slow scrollers move too slowly"),
+
     // For key bindings, the values stored in the key_* variables       // phares
     // are the internal Doom Codes. The values stored in the default.cfg
     // file are the keyboard codes. I_ScanCode2DoomCode converts from

--- a/source/mn_menus.cpp
+++ b/source/mn_menus.cpp
@@ -2915,19 +2915,20 @@ static menuitem_t mn_compat1_items[] = {
 
 static menuitem_t mn_compat2_items[] = {
     { it_title,  "Compatibility",                       nullptr,           "m_compat", 0                 },
-    { it_gap,    nullptr,                               nullptr,           nullptr,    0                 },
-    { it_info,   "Simulation",                          nullptr,           nullptr,    MENUITEM_CENTERED },
-    { it_toggle, "Actors get stuck over dropoffs",      "comp_dropoff",    nullptr,    0                 },
-    { it_toggle, "Actors never fall off ledges",        "comp_falloff",    nullptr,    0                 },
-    { it_toggle, "Spawncubes telefrag on MAP30 only",   "comp_telefrag",   nullptr,    0                 },
-    { it_toggle, "Monsters can respawn outside map",    "comp_respawnfix", nullptr,    0                 },
-    { it_toggle, "Disable terrain types",               "comp_terrain",    nullptr,    0                 },
-    { it_toggle, "Disable falling damage",              "comp_fallingdmg", nullptr,    0                 },
-    { it_toggle, "Actors have infinite height",         "comp_overunder",  nullptr,    0                 },
-    { it_toggle, "Doom actor heights are inaccurate",   "comp_theights",   nullptr,    0                 },
-    { it_toggle, "Bullets never hit floors & ceilings", "comp_planeshoot", nullptr,    0                 },
-    { it_toggle, "Respawns are sometimes silent in DM", "comp_ninja",      nullptr,    0                 },
-    { it_end,    nullptr,                               nullptr,           nullptr,    0                 }
+    { it_gap,    nullptr,                               nullptr,               nullptr,    0                 },
+    { it_info,   "Simulation",                          nullptr,               nullptr,    MENUITEM_CENTERED },
+    { it_toggle, "Actors get stuck over dropoffs",      "comp_dropoff",        nullptr,    0                 },
+    { it_toggle, "Actors never fall off ledges",        "comp_falloff",        nullptr,    0                 },
+    { it_toggle, "Spawncubes telefrag on MAP30 only",   "comp_telefrag",       nullptr,    0                 },
+    { it_toggle, "Monsters can respawn outside map",    "comp_respawnfix",     nullptr,    0                 },
+    { it_toggle, "Disable terrain types",               "comp_terrain",        nullptr,    0                 },
+    { it_toggle, "Disable falling damage",              "comp_fallingdmg",     nullptr,    0                 },
+    { it_toggle, "Actors have infinite height",         "comp_overunder",      nullptr,    0                 },
+    { it_toggle, "Doom actor heights are inaccurate",   "comp_theights",       nullptr,    0                 },
+    { it_toggle, "Bullets never hit floors & ceilings", "comp_planeshoot",     nullptr,    0                 },
+    { it_toggle, "Respawns are sometimes silent in DM", "comp_ninja",          nullptr,    0                 },
+    { it_toggle, "Voodoo dolls may move too slowly",    "comp_voodooscroller", nullptr,    0                 },
+    { it_end,    nullptr,                               nullptr,               nullptr,    0                 }
 };
 
 static menuitem_t mn_compat3_items[] = {

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -610,6 +610,7 @@ void P_ThrustMobj(Mobj *mo, angle_t angle, fixed_t move, bool nolimit)
         mo->intflags |= MIF_NOSPEEDCAP;
     mo->momx += FixedMul(move, finecosine[angle]);
     mo->momy += FixedMul(move, finesine[angle]);
+    mo->intflags |= MIF_SCROLLING;
 }
 
 //
@@ -994,7 +995,8 @@ void P_XYMovement(Mobj *mo)
     // moving corresponding player, except in old demos:
 
     if(mo->momx > -STOPSPEED && mo->momx < STOPSPEED && mo->momy > -STOPSPEED && mo->momy < STOPSPEED &&
-       (!player || !(player->cmd.forwardmove | player->cmd.sidemove) || (player->mo != mo && demo_version >= 203)))
+       (!player || !(player->cmd.forwardmove | player->cmd.sidemove)
+           || (player->mo != mo && demo_version >= 203 && (comp[comp_voodooscroller] || !(mo->intflags & MIF_SCROLLING)))))
     {
         // if in a walking frame, stop moving
 
@@ -1837,6 +1839,7 @@ void Mobj::Think()
     if(momx | momy || flags & MF_SKULLFLY)
     {
         P_XYMovement(this);
+        intflags &= ~MIF_SCROLLING;
         if(removed) // killough: mobj was removed
             return;
     }

--- a/source/p_mobj.cpp
+++ b/source/p_mobj.cpp
@@ -610,7 +610,6 @@ void P_ThrustMobj(Mobj *mo, angle_t angle, fixed_t move, bool nolimit)
         mo->intflags |= MIF_NOSPEEDCAP;
     mo->momx += FixedMul(move, finecosine[angle]);
     mo->momy += FixedMul(move, finesine[angle]);
-    mo->intflags |= MIF_SCROLLING;
 }
 
 //

--- a/source/p_mobj.h
+++ b/source/p_mobj.h
@@ -879,6 +879,7 @@ enum
     MIF_SKULLFLYSEE           = 0x00080000, // ioanch: when MF_SKULLFLY is set, return to seestate, not spawn
 
     MIF_NOSPEEDCAP = 0x00100000, // Don't apply MAXMOVE speed limit when thrusted
+    MIF_SCROLLING  = 0x00200000, // Object is affected by scroller / pusher / puller
 
     // these should be cleared when a thing is being raised
     MIF_CLEARRAISED = (MIF_DIEDFALLING | MIF_SCREAMED | MIF_CRASHED | MIF_SKULLFLYSEE | MIF_WIMPYDEATH),

--- a/source/p_pushers.cpp
+++ b/source/p_pushers.cpp
@@ -162,6 +162,7 @@ static bool PIT_PushThing(Mobj *thing, void *context)
                 pushangle += ANG180; // away
 
             P_ThrustMobj(thing, pushangle, speed, false);
+            thing->intflags |= MIF_SCROLLING;
         }
     }
     return true;

--- a/source/p_scroll.cpp
+++ b/source/p_scroll.cpp
@@ -189,6 +189,7 @@ void ScrollThinker::Think()
             {
                 thing->momx += dx;
                 thing->momy += dy;
+                thing->intflags |= MIF_SCROLLING;
             }
         }
         break;


### PR DESCRIPTION
Quick standalone test: [scroll speed test.zip](https://github.com/user-attachments/files/31892922/scroll.speed.test.zip)
(note that even with the setting disabled, if you press the switch while standing still, the voodoo doll will still move too slowly until _you_ start moving again, but that's consistent with what happens in dsda-doom)

The other mbf21 flags should be added at some point too, but I don't have readily available tests for the others, and this one (IMO) is probably the most likely to result in maps not working as intended. For example, MAP36 of Doom 2 in City Only has some voodoo-driven combat setpieces that progress way too slowly to the point they might seem like softlocks if you don't already know what's supposed to happen.